### PR TITLE
add MYSQL 8.0 macro

### DIFF
--- a/src/server/shared/Database/QueryResult.h
+++ b/src/server/shared/Database/QueryResult.h
@@ -27,6 +27,10 @@
 #endif
 #include <mysql.h>
 
+#if MYSQL_VERSION_ID>80001
+typedef bool my_bool;
+#endif
+
 class ResultSet
 {
     public:


### PR DESCRIPTION
Add support to MySQL 8.0

def my_bool

my_bool has been renamed to bool in MySQL 8.0.
https://dev.mysql.com/doc/refman/8.0/en/c-api-prepared-statement-data-structures.html