### PR TITLE
add quest objective id to quest poi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.vs
 build/
 .DS_Store
+.idea/

--- a/sql/updates/master/world/2024_06_14_00.sql
+++ b/sql/updates/master/world/2024_06_14_00.sql
@@ -1,8 +1,8 @@
--- Add column QuestObjectiveId
+# Add column QuestObjectiveId
 ALTER TABLE `quest_poi`
 ADD COLUMN IF NOT EXISTS `QuestObjectiveId` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `objIndex`;
 
--- Try to populate with reasonable quest objective data
+# Try to populate with reasonable quest objective data
 update quest_poi
     inner join
     (
@@ -13,4 +13,22 @@ update quest_poi
     ) objective
     on quest_poi.questId = objective.questId
 set QuestObjectiveId = objective.id
-where objIndex >= 0 # ignore turn-in quest POIs
+where objIndex >= 0; # ignore turn-in quest POIs
+
+# Quest 8325 - Reclaiming Sunstrider Isle
+# fix line break in offer reward text
+set @ENTRY := 8325;
+update quest_template set OfferRewardText = 'You have successfully completed your first task; for that, you are to be congratulated.  Such success gives me faith that you will turn out better than those young blood elves who fail to heed the lessons of their masters.  Continued success will be rewarded - not only with knowledge, but also with tangible rewards as well.$B$BYour work here, however, is not finished.  There is much more to learn, my young friend... '
+where id = @ENTRY;
+
+# Well Watcher Solanian
+# fix position
+set @ENTRY := 15295;
+update creature set position_x = 10376.4, position_y = -6406.69, position_z = 49.798, orientation = 3.58665 where id = @ENTRY;
+
+# Quest 8330 - Solanian's Belongings
+# fix quest poi objective/index
+set @ENTRY := 8330;
+update quest_poi set objIndex = 0, QuestObjectiveId = 256353 where questId = @ENTRY and id = 1;
+update quest_poi set objIndex = 1, QuestObjectiveId = 256354 where questId = @ENTRY and id = 2;
+update quest_poi set objIndex = 2, QuestObjectiveId = 256355 where questId = @ENTRY and id = 3;

--- a/sql/updates/master/world/2024_06_14_00.sql
+++ b/sql/updates/master/world/2024_06_14_00.sql
@@ -1,0 +1,16 @@
+-- Add column QuestObjectiveId
+ALTER TABLE `quest_poi`
+ADD COLUMN IF NOT EXISTS `QuestObjectiveId` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `objIndex`;
+
+-- Try to populate with reasonable quest objective data
+update quest_poi
+    inner join
+    (
+        select questId, min(Id) as id from quest_objective
+        where type in (0, 1, 2) # monster, item, game object
+        group by questId
+        having count(Id) = 1
+    ) objective
+    on quest_poi.questId = objective.questId
+set QuestObjectiveId = objective.id
+where objIndex >= 0 # ignore turn-in quest POIs

--- a/sql/updates/master/world/2024_06_14_00.sql
+++ b/sql/updates/master/world/2024_06_14_00.sql
@@ -1,8 +1,8 @@
-# Add column QuestObjectiveId
+-- Add column QuestObjectiveId
 ALTER TABLE `quest_poi`
-ADD COLUMN IF NOT EXISTS `QuestObjectiveId` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `objIndex`;
+ADD COLUMN `QuestObjectiveId` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `objIndex`;
 
-# Try to populate with reasonable quest objective data
+-- Try to populate with reasonable quest objective data
 update quest_poi
     inner join
     (
@@ -15,19 +15,19 @@ update quest_poi
 set QuestObjectiveId = objective.id
 where objIndex >= 0; # ignore turn-in quest POIs
 
-# Quest 8325 - Reclaiming Sunstrider Isle
-# fix line break in offer reward text
+-- Quest 8325 - Reclaiming Sunstrider Isle
+-- fix line break in offer reward text
 set @ENTRY := 8325;
 update quest_template set OfferRewardText = 'You have successfully completed your first task; for that, you are to be congratulated.  Such success gives me faith that you will turn out better than those young blood elves who fail to heed the lessons of their masters.  Continued success will be rewarded - not only with knowledge, but also with tangible rewards as well.$B$BYour work here, however, is not finished.  There is much more to learn, my young friend... '
 where id = @ENTRY;
 
-# Well Watcher Solanian
-# fix position
+-- Well Watcher Solanian
+-- fix position
 set @ENTRY := 15295;
 update creature set position_x = 10376.4, position_y = -6406.69, position_z = 49.798, orientation = 3.58665 where id = @ENTRY;
 
-# Quest 8330 - Solanian's Belongings
-# fix quest poi objective/index
+-- Quest 8330 - Solanian's Belongings
+-- fix quest poi objective/index
 set @ENTRY := 8330;
 update quest_poi set objIndex = 0, QuestObjectiveId = 256353 where questId = @ENTRY and id = 1;
 update quest_poi set objIndex = 1, QuestObjectiveId = 256354 where questId = @ENTRY and id = 2;

--- a/sql/updates/master/world/2024_06_14_00.sql
+++ b/sql/updates/master/world/2024_06_14_00.sql
@@ -7,13 +7,13 @@ update quest_poi
     inner join
     (
         select questId, min(Id) as id from quest_objective
-        where type in (0, 1, 2) # monster, item, game object
+        where type in (0, 1, 2) -- monster, item, game object
         group by questId
         having count(Id) = 1
     ) objective
     on quest_poi.questId = objective.questId
 set QuestObjectiveId = objective.id
-where objIndex >= 0; # ignore turn-in quest POIs
+where objIndex >= 0; -- ignore turn-in quest POIs
 
 -- Quest 8325 - Reclaiming Sunstrider Isle
 -- fix line break in offer reward text

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -7551,8 +7551,8 @@ void ObjectMgr::LoadQuestPOI()
 
     uint32 count = 0;
 
-    //                                               0        1   2         3      4               5        6     7
-    QueryResult result = WorldDatabase.Query("SELECT questId, id, objIndex, mapid, WorldMapAreaId, FloorId, unk3, unk4 FROM quest_poi order by questId");
+    //                                                   0        1   2         3                 4      5               6        7     8
+    QueryResult result = WorldDatabase.Query("SELECT questId, id, objIndex, QuestObjectiveId, mapid, WorldMapAreaId, FloorId, unk3, unk4 FROM quest_poi order by questId");
 
     if (!result)
     {
@@ -7596,13 +7596,14 @@ void ObjectMgr::LoadQuestPOI()
         uint32 questId            = fields[0].GetUInt32();
         uint32 id                 = fields[1].GetUInt32();
         int32 objIndex            = fields[2].GetInt32();
-        uint32 mapId              = fields[3].GetUInt32();
-        uint32 WorldMapAreaId     = fields[4].GetUInt32();
-        uint32 FloorId            = fields[5].GetUInt32();
-        uint32 unk3               = fields[6].GetUInt32();
-        uint32 unk4               = fields[7].GetUInt32();
+        uint32 questObjectiveId   = fields[3].GetUInt32();
+        uint32 mapId              = fields[4].GetUInt32();
+        uint32 WorldMapAreaId     = fields[5].GetUInt32();
+        uint32 FloorId            = fields[6].GetUInt32();
+        uint32 unk3               = fields[7].GetUInt32();
+        uint32 unk4               = fields[8].GetUInt32();
 
-        QuestPOI POI(id, objIndex, mapId, WorldMapAreaId, FloorId, unk3, unk4);
+        QuestPOI POI(id, objIndex, questObjectiveId, mapId, WorldMapAreaId, FloorId, unk3, unk4);
         POI.points = POIs[questId][id];
 
         _questPOIStore[questId].push_back(POI);

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -624,6 +624,7 @@ struct QuestPOI
 {
     uint32 Id;
     int32 ObjectiveIndex;
+    uint32 QuestObjectiveId;
     uint32 MapId;
     uint32 AreaId;
     uint32 FloorId;
@@ -631,8 +632,8 @@ struct QuestPOI
     uint32 Unk4;
     std::vector<QuestPOIPoint> points;
 
-    QuestPOI() : Id(0), ObjectiveIndex(0), MapId(0), AreaId(0), FloorId(0), Unk3(0), Unk4(0) { }
-    QuestPOI(uint32 id, int32 objIndex, uint32 mapId, uint32 areaId, uint32 floorId, uint32 unk3, uint32 unk4) : Id(id), ObjectiveIndex(objIndex), MapId(mapId), AreaId(areaId), FloorId(floorId), Unk3(unk3), Unk4(unk4) { }
+    QuestPOI() : Id(0), ObjectiveIndex(0), QuestObjectiveId(0), MapId(0), AreaId(0), FloorId(0), Unk3(0), Unk4(0) { }
+    QuestPOI(uint32 id, int32 objIndex, uint32 questObjectiveId, uint32 mapId, uint32 areaId, uint32 floorId, uint32 unk3, uint32 unk4) : Id(id), ObjectiveIndex(objIndex), QuestObjectiveId(questObjectiveId), MapId(mapId), AreaId(areaId), FloorId(floorId), Unk3(unk3), Unk4(unk4) { }
 };
 
 typedef std::vector<QuestPOI> QuestPOIVector;

--- a/src/server/game/Handlers/QueryHandler.cpp
+++ b/src/server/game/Handlers/QueryHandler.cpp
@@ -787,7 +787,7 @@ void WorldSession::HandleQuestPOIQuery(WorldPacket& recvData)
 
                     poiData << int32(itr->ObjectiveIndex);      // objective index
                     poiData << uint32(itr->Id);                 // POI index
-                    poiData << uint32(0);                       // unknown (new 5.x.x)
+                    poiData << uint32(itr->QuestObjectiveId);   // quest objective id
                     poiData << uint32(0);                       // unknown (new 5.x.x)
                     poiData << uint32(itr->MapId);              // mapid
                     poiData << uint32(itr->points.size());      // POI points count


### PR DESCRIPTION
This adds quest objective support to POI tooltips in the map.

Before this change:

![quest-poi-quest-objective-missing](https://github.com/Legends-of-Azeroth/Legends-of-Azeroth-Pandaria-5.4.8/assets/1695733/e94f6911-fbf1-4efc-b931-5a39d349578a)

After this change:

![quest-poi-quest-objective-present](https://github.com/Legends-of-Azeroth/Legends-of-Azeroth-Pandaria-5.4.8/assets/1695733/fb902b7f-2de2-42af-9c67-6b5b60db5a43)

The column is populated with some data, but there will probably be cases where data is incorrect and/or missing, and will require future updates, but this seems better than leaving everything empty by default.