### PR TITLE
FIX: skip greeting for npcs with one quest

### DIFF
--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1688,7 +1688,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
     }
 
     void PrepareQuestMenu(uint64 guid);
-    void SendPreparedQuest(uint64 guid);
+    void SendPreparedQuest(WorldObject* source);
     bool IsActiveQuest(uint32 quest_id) const;
     Quest const* GetNextQuest(uint64 guid, Quest const* quest);
     bool CanSeeStartQuest(Quest const* quest);

--- a/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/old_hillsbrad.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/old_hillsbrad.cpp
@@ -247,7 +247,7 @@ public:
         if (creature->IsQuestGiver())
         {
             player->PrepareQuestMenu(creature->GetGUID());
-            player->SendPreparedQuest(creature->GetGUID());
+            player->SendPreparedQuest(creature);
         }
 
         InstanceScript* instance = creature->GetInstanceScript();

--- a/src/server/scripts/Outland/zone_netherstorm.cpp
+++ b/src/server/scripts/Outland/zone_netherstorm.cpp
@@ -315,7 +315,7 @@ public:
         if (go->GetGoType() == GAMEOBJECT_TYPE_QUESTGIVER)
         {
             player->PrepareQuestMenu(go->GetGUID());
-            player->SendPreparedQuest(go->GetGUID());
+            player->SendPreparedQuest(go);
         }
 
         Creature* manaforge = NULL;


### PR DESCRIPTION
This skips the gossip menu/greeting for NPCs that have one quest available. The updated methods now match TC master branch.

Before this change:

1. Create a new Blood Elf
2. Talk to first quest giver
3. Note that you have to click past the greeting into the menu to auto accept the first quest (this is also the case for quest turn ins)

After this change:

1. Create a new Blood Elf
2. Talk to first quest giver
3. Greeting is skipped and first quest is auto-accepted