### PR TITLE
[Core/Questing] Rework GetQuestDialogStatus; support legendary quest icons

### DIFF
--- a/src/server/game/AI/CoreAI/GameObjectAI.h
+++ b/src/server/game/AI/CoreAI/GameObjectAI.h
@@ -52,7 +52,7 @@ class TC_GAME_API GameObjectAI
         virtual bool OnGossipSelectCode(Player* /*player*/, uint32 /*sender*/, uint32 /*action*/, char const* /*code*/) { return false; }
         virtual bool OnQuestAccept(Player* /*player*/, Quest const* /*quest*/) { return false; }
         virtual bool OnQuestReward(Player* /*player*/, Quest const* /*quest*/, uint32 /*opt*/) { return false; }
-        virtual uint32 GetDialogStatus(Player* /*player*/) { return 100; }
+        virtual Optional<QuestGiverStatus> GetDialogStatus(Player* /*player*/) { return {}; }
         virtual void Destroyed(Player* /*player*/, uint32 /*eventId*/) { }
         virtual uint32 GetData(uint32 /*id*/) const { return 0; }
         virtual void SetData64(uint32 /*id*/, uint64 /*value*/) { }

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -29,6 +29,7 @@ class Creature;
 class Player;
 class PlayerAI;
 class SpellInfo;
+enum class QuestGiverStatus : uint32;
 
 #define TIME_INTERVAL_LOOK   5000
 #define VISIBILITY_RANGE    10000
@@ -182,8 +183,7 @@ class TC_GAME_API CreatureAI : public UnitAI
         /// == Gossip system ================================
 
         // Called when the dialog status between a player and the creature is requested.
-        //virtual Optional<QuestGiverStatus> GetDialogStatus(Player* /*player*/) { return {}; }
-        virtual uint32 GetDialogStatus(Player* /*player*/) { return 100; } // todo
+        virtual Optional<QuestGiverStatus> GetDialogStatus(Player* /*player*/) { return {}; }
 
         // Called when a player opens a gossip dialog with the creature.
         virtual bool OnGossipHello(Player* /*player*/) { return false; }

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -1046,8 +1046,7 @@ bool SmartGameObjectAI::OnQuestReward(Player* player, Quest const* quest, uint32
     return false;
 }
 
-// Called when the dialog status between a player and the gameobject is requested.
-uint32 SmartGameObjectAI::GetDialogStatus(Player* /*player*/) { return 100; }
+Optional<QuestGiverStatus> SmartGameObjectAI::GetDialogStatus(Player* /*player*/) { return {}; }
 
 // Called when the gameobject is destroyed (destructible buildings only).
 void SmartGameObjectAI::Destroyed(Player* player, uint32 eventId)

--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -282,7 +282,7 @@ class TC_GAME_API SmartGameObjectAI : public GameObjectAI
         bool OnGossipSelectCode(Player* /*player*/, uint32 /*sender*/, uint32 /*action*/, const char* /*code*/) override;
         bool OnQuestAccept(Player* player, Quest const* quest) override;
         bool OnQuestReward(Player* player, Quest const* quest, uint32 opt) override;
-        uint32 GetDialogStatus(Player* /*player*/) override;
+        Optional<QuestGiverStatus> GetDialogStatus(Player* /*player*/) override;
         void Destroyed(Player* player, uint32 eventId) override;
         void SetData(uint32 id, uint32 value) override;
         void SetScript9(SmartScriptHolder& e, uint32 entry, Unit* invoker);

--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -19,6 +19,7 @@
 #include "GossipDef.h"
 #include "ObjectMgr.h"
 #include "Opcodes.h"
+#include "QuestDef.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
 #include "Formulas.h"
@@ -433,7 +434,7 @@ void PlayerMenu::SendQuestGiverQuestList(QEmote eEmote, const std::string& Title
     TC_LOG_DEBUG("network", "WORLD: Sent SMSG_QUESTGIVER_QUEST_LIST NPC Guid=%u", GUID_LOPART(npcGUID));
 }
 
-void PlayerMenu::SendQuestGiverStatus(uint32 questStatus, uint64 npcGUID) const
+void PlayerMenu::SendQuestGiverStatus(QuestGiverStatus questStatus, uint64 npcGUID) const
 {
     ObjectGuid guid = npcGUID;
 

--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -19,7 +19,6 @@
 #include "GossipDef.h"
 #include "ObjectMgr.h"
 #include "Opcodes.h"
-#include "QuestDef.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
 #include "Formulas.h"

--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -19,7 +19,6 @@
 #define TRINITYCORE_GOSSIP_H
 
 #include "Common.h"
-#include "QuestDef.h"
 #include "NPCHandler.h"
 
 class WorldSession;

--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -336,7 +336,7 @@ class PlayerMenu
         /*********************************************************/
         /***                    QUEST SYSTEM                   ***/
         /*********************************************************/
-        void SendQuestGiverStatus(uint32 questStatus, uint64 npcGUID) const;
+        void SendQuestGiverStatus(QuestGiverStatus questStatus, uint64 npcGUID) const;
 
         void SendQuestGiverQuestList(QEmote eEmote, const std::string& Title, uint64 npcGUID);
 

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1695,6 +1695,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
     bool GetQuestRewardStatus(uint32 quest_id) const;
     QuestStatus GetQuestStatus(uint32 quest_id) const;
     void SetQuestStatus(uint32 quest_id, QuestStatus status, bool update = true);
+    QuestGiverStatus GetQuestDialogStatus(Object const* questgiver);
     void RemoveActiveQuest(uint32 quest_id, bool update = true, bool removeFromQuestLog = false);
     void RemoveRewardedQuest(uint32 quest_id, bool update = true);
     void SendQuestUpdate(uint32 questId);

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1687,6 +1687,8 @@ public:
     bool IsUnderWater() const;
     bool isInAccessiblePlaceFor(Creature const* c) const;
 
+    bool IsInteractionAllowedWhileHostile() const { return HasUnitFlag2(UNIT_FLAG2_ALLOW_ENEMY_INTERACT); }
+
     void SendHealSpellLog(Unit* victim, uint32 SpellID, uint32 Damage, uint32 OverHeal, uint32 Absorb, bool critical = false);
     int32 HealBySpell(Unit* victim, SpellInfo const* spellInfo, uint32 addHealth, bool critical = false);
     void SendEnergizeSpellLog(Unit* victim, uint32 spellID, int32 damage, Powers powertype);

--- a/src/server/game/LuaEngine/HookMgr.cpp
+++ b/src/server/game/LuaEngine/HookMgr.cpp
@@ -380,17 +380,17 @@ bool HookMgr::OnQuestReward(Player* pPlayer, Creature* pCreature, Quest const* p
     return true;
 }
 
-uint32 HookMgr::GetDialogStatus(Player* pPlayer, Creature* pCreature)
+Optional<QuestGiverStatus> HookMgr::GetDialogStatus(Player* pPlayer, Creature* pCreature)
 {
     int bind = sEluna->CreatureEventBindings->GetBind(pCreature->GetEntry(), CREATURE_EVENT_ON_DIALOG_STATUS);
     if (!bind)
-        return 0;
+        return std::nullopt;
     sEluna->BeginCall(bind);
     sEluna->Push(sEluna->L, CREATURE_EVENT_ON_DIALOG_STATUS);
     sEluna->Push(sEluna->L, pPlayer);
     sEluna->Push(sEluna->L, pCreature);
     sEluna->ExecuteCall(3, 0);
-    return DIALOG_STATUS_INCOMPLETE;
+    return QuestGiverStatus::Incomplete;
 }
 // gameobject
 bool HookMgr::OnDummyEffect(Unit* pCaster, uint32 spellId, SpellEffIndex effIndex, GameObject* pTarget)
@@ -497,17 +497,17 @@ bool HookMgr::OnQuestReward(Player* pPlayer, GameObject* pGameObject, Quest cons
     return true;
 }
 
-uint32 HookMgr::GetDialogStatus(Player* pPlayer, GameObject* pGameObject)
+Optional<QuestGiverStatus> HookMgr::GetDialogStatus(Player* pPlayer, GameObject* pGameObject)
 {
     int bind = sEluna->GameObjectEventBindings->GetBind(pGameObject->GetEntry(), GAMEOBJECT_EVENT_ON_DIALOG_STATUS);
     if (!bind)
-        return 0;
+        return std::nullopt;
     sEluna->BeginCall(bind);
     sEluna->Push(sEluna->L, GAMEOBJECT_EVENT_ON_DIALOG_STATUS);
     sEluna->Push(sEluna->L, pPlayer);
     sEluna->Push(sEluna->L, pGameObject);
     sEluna->ExecuteCall(3, 0);
-    return DIALOG_STATUS_INCOMPLETE; // DIALOG_STATUS_UNDEFINED
+    return QuestGiverStatus::Incomplete;
 }
 
 void HookMgr::OnDestroyed(GameObject* pGameObject, Player* pPlayer)

--- a/src/server/game/LuaEngine/HookMgr.h
+++ b/src/server/game/LuaEngine/HookMgr.h
@@ -296,7 +296,7 @@ struct HookMgr
     bool OnQuestSelect(Player* pPlayer, Creature* pCreature, Quest const* pQuest);
     bool OnQuestComplete(Player* pPlayer, Creature* pCreature, Quest const* pQuest);
     bool OnQuestReward(Player* pPlayer, Creature* pCreature, Quest const* pQuest);
-    uint32 GetDialogStatus(Player* pPlayer, Creature* pCreature);
+    Optional<QuestGiverStatus> GetDialogStatus(Player* pPlayer, Creature* pCreature);
     /* GameObject */
     bool OnDummyEffect(Unit* pCaster, uint32 spellId, SpellEffIndex effIndex, GameObject* pTarget);
     bool OnGossipHello(Player* pPlayer, GameObject* pGameObject);
@@ -306,7 +306,7 @@ struct HookMgr
     bool OnQuestComplete(Player* pPlayer, GameObject* pGameObject, Quest const* pQuest);
     bool OnQuestReward(Player* pPlayer, GameObject* pGameObject, Quest const* pQuest);
     bool OnGameObjectUse(Player* pPlayer, GameObject* pGameObject) { return false; }; // TODO? Not on TC
-    uint32 GetDialogStatus(Player* pPlayer, GameObject* pGameObject);
+    Optional<QuestGiverStatus> GetDialogStatus(Player* pPlayer, GameObject* pGameObject);
     void OnDestroyed(GameObject* pGameObject, Player* pPlayer);
     void OnDamaged(GameObject* pGameObject, Player* pPlayer);
     void OnLootStateChanged(GameObject* pGameObject, uint32 state, Unit* pUnit);

--- a/src/server/game/Quests/QuestDef.h
+++ b/src/server/game/Quests/QuestDef.h
@@ -295,7 +295,7 @@ class Quest
 {
     friend class ObjectMgr;
     public:
-        explicit Quest(Field*);// questRecord);
+        Quest(Field* questRecord);
         uint32 XPValue(Player* player) const;
 
         bool HasFlag(uint32 flag) const { return (Flags & flag) != 0; }

--- a/src/server/game/Quests/QuestDef.h
+++ b/src/server/game/Quests/QuestDef.h
@@ -22,6 +22,7 @@
 #include "SharedDefines.h"
 #include "WorldPacket.h"
 #include "DBCEnums.h"
+#include "EnumFlag.h"
 
 #include <string>
 #include <vector>
@@ -104,21 +105,25 @@ enum QuestStatus
     MAX_QUEST_STATUS
 };
 
-enum QuestGiverStatus
+enum class QuestGiverStatus : uint32
 {
-    DIALOG_STATUS_NONE                     = 0x000,
-    DIALOG_STATUS_UNK                      = 0x001,
-    DIALOG_STATUS_UNAVAILABLE              = 0x002,
-    DIALOG_STATUS_LOW_LEVEL_AVAILABLE      = 0x004,
-    DIALOG_STATUS_LOW_LEVEL_REWARD_REP     = 0x008,
-    DIALOG_STATUS_LOW_LEVEL_AVAILABLE_REP  = 0x010,
-    DIALOG_STATUS_INCOMPLETE               = 0x020,
-    DIALOG_STATUS_REWARD_REP               = 0x040,
-    DIALOG_STATUS_AVAILABLE_REP            = 0x080,
-    DIALOG_STATUS_AVAILABLE                = 0x100,
-    DIALOG_STATUS_REWARD2                  = 0x200,         // no yellow dot on minimap
-    DIALOG_STATUS_REWARD                   = 0x400          // yellow dot on minimap
+    None                         = 0x0000,
+    Future                       = 0x0002,
+    Trivial                      = 0x0004,
+    TrivialRepeatableTurnin      = 0x0008,
+    TrivialDailyQuest            = 0x0010,
+    Incomplete                   = 0x0020,
+    RepeatableTurnin             = 0x0040,
+    DailyQuest                   = 0x0080,
+    Quest                        = 0x0100,
+    RewardCompleteNoPOI          = 0x0200,
+    RewardCompletePOI            = 0x0400,
+    LegendaryQuest               = 0x0800,
+    LegendaryRewardCompleteNoPOI = 0x1000,
+    LegendaryRewardCompletePOI   = 0x2000
 };
+
+DEFINE_ENUM_FLAG(QuestGiverStatus);
 
 enum QuestFlags
 {
@@ -290,7 +295,7 @@ class Quest
 {
     friend class ObjectMgr;
     public:
-        Quest(Field* questRecord);
+        explicit Quest(Field*);// questRecord);
         uint32 XPValue(Player* player) const;
 
         bool HasFlag(uint32 flag) const { return (Flags & flag) != 0; }

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -952,20 +952,19 @@ bool ScriptMgr::OnQuestReward(Player* player, Creature* creature, Quest const* q
     return tmpscript->OnQuestReward(player, creature, quest, opt);
 }
 
-uint32 ScriptMgr::GetDialogStatus(Player* player, Creature* creature)
+Optional<QuestGiverStatus> ScriptMgr::GetDialogStatus(Player* player, Creature* creature)
 {
     ASSERT(player);
     ASSERT(creature);
 #ifdef ELUNA
-    if (uint32 dialogid = sHookMgr->GetDialogStatus(player, creature))
+    if (Optional<QuestGiverStatus> status = sHookMgr->GetDialogStatus(player, creature))
     {
         player->PlayerTalkClass->ClearMenus();
-        return dialogid;
+        return *status;
     }
 #endif
 
-    /// @todo 100 is a funny magic number to have hanging around here...
-    GET_SCRIPT_RET(CreatureScript, creature->GetScriptId(), tmpscript, 100);
+    GET_SCRIPT_RET(CreatureScript, creature->GetScriptId(), tmpscript, std::nullopt);
     player->PlayerTalkClass->ClearMenus();
     return tmpscript->GetDialogStatus(player, creature);
 }
@@ -1085,20 +1084,19 @@ bool ScriptMgr::OnQuestReward(Player* player, GameObject* go, Quest const* quest
     return tmpscript->OnQuestReward(player, go, quest, opt);
 }
 
-uint32 ScriptMgr::GetDialogStatus(Player* player, GameObject* go)
+Optional<QuestGiverStatus> ScriptMgr::GetDialogStatus(Player* player, GameObject* go)
 {
     ASSERT(player);
     ASSERT(go);
 #ifdef ELUNA
-    if (uint32 dialogid = sHookMgr->GetDialogStatus(player, go))
+    if (Optional<QuestGiverStatus> status = sHookMgr->GetDialogStatus(player, go))
     {
         player->PlayerTalkClass->ClearMenus();
-        return dialogid;
+        return *status;
     }
 #endif
 
-    /// @todo 100 is a funny magic number to have hanging around here...
-    GET_SCRIPT_RET(GameObjectScript, go->GetScriptId(), tmpscript, 100);
+    GET_SCRIPT_RET(GameObjectScript, go->GetScriptId(), tmpscript, std::nullopt);
     player->PlayerTalkClass->ClearMenus();
     return tmpscript->GetDialogStatus(player, go);
 }

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -63,6 +63,8 @@ class WorldPacket;
 class WorldSocket;
 class WorldObject;
 
+enum class QuestGiverStatus : uint32;
+
 struct AuctionEntry;
 struct ConditionSourceInfo;
 struct Condition;
@@ -448,7 +450,7 @@ class CreatureScript : public ScriptObject
         virtual bool OnQuestReward(Player* /*player*/, Creature* /*creature*/, Quest const* /*quest*/, uint32 /*opt*/) { return false; }
 
         // Called when the dialog status between a player and the creature is requested.
-        virtual uint32 GetDialogStatus(Player* /*player*/, Creature* /*creature*/) { return 100; }
+        virtual Optional<QuestGiverStatus> GetDialogStatus(Player* /*player*/, Creature* /*creature*/) { return {}; }
 
         // Called when a CreatureAI object is needed for the creature.
         virtual CreatureAI* GetAI(Creature* /*creature*/) const { return NULL; }
@@ -484,7 +486,7 @@ class GameObjectScript : public ScriptObject, public UpdatableScript<GameObject>
         virtual bool OnQuestReward(Player* /*player*/, GameObject* /*go*/, Quest const* /*quest*/, uint32 /*opt*/) { return false; }
 
         // Called when the dialog status between a player and the gameobject is requested.
-        virtual uint32 GetDialogStatus(Player* /*player*/, GameObject* /*go*/) { return 100; }
+        virtual Optional<QuestGiverStatus> GetDialogStatus(Player* /*player*/, GameObject* /*go*/) { return {}; }
 
         // Called when the game object is destroyed (destructible buildings only).
         virtual void OnDestroyed(GameObject* /*go*/, Player* /*player*/) { }
@@ -1047,7 +1049,7 @@ class TC_GAME_API ScriptMgr
         bool OnQuestSelect(Player* player, Creature* creature, Quest const* quest);
         bool OnQuestComplete(Player* player, Creature* creature, Quest const* quest);
         bool OnQuestReward(Player* player, Creature* creature, Quest const* quest, uint32 opt);
-        uint32 GetDialogStatus(Player* player, Creature* creature);
+        Optional<QuestGiverStatus> GetDialogStatus(Player* player, Creature* creature);
         CreatureAI* GetCreatureAI(Creature* creature);
 
     public: /* GameObjectScript */
@@ -1059,7 +1061,7 @@ class TC_GAME_API ScriptMgr
         bool OnGossipSelectCode(Player* player, GameObject* go, uint32 sender, uint32 action, const char* code);
         bool OnQuestAccept(Player* player, GameObject* go, Quest const* quest);
         bool OnQuestReward(Player* player, GameObject* go, Quest const* quest, uint32 opt);
-        uint32 GetDialogStatus(Player* player, GameObject* go);
+        Optional<QuestGiverStatus> GetDialogStatus(Player* player, GameObject* go);
         void OnGameObjectDestroyed(GameObject* go, Player* player);
         void OnGameObjectDamaged(GameObject* go, Player* player);
         void OnGameObjectLootStateChanged(GameObject* go, uint32 state, Unit* unit);

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -442,7 +442,6 @@ class TC_GAME_API WorldSession
 
         uint32 GetLatency() const { return m_latency; }
         void SetLatency(uint32 latency) { m_latency = latency; }
-        uint32 getDialogStatus(Player* player, Object* questgiver, uint32 defstatus);
 
         std::atomic<time_t> m_timeOutTime;
         void UpdateTimeOutTime(uint32 diff)


### PR DESCRIPTION
This reworks `Player::GetQuestDialogStatus` - functionality is based on TC master, and is mostly the same, except legendary icons are now supported with the expanded `QuestGiverStatus` enum. I manually verified each of the enum values, which is why it's slightly different than TC master.

There are basically two tests:

- General questing
  - Icons should be correct when accepting, in progress, ready to turn in, etc.
- Legendary quest icon
  - `.character level 90`
  - `.go creature 514060`
  - Verify correct color of quest icon (legendary is more orange than normal)