### PR TITLE
[Core/Spells] Fix spell effect leap (mage blink)

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5222,7 +5222,7 @@ void Spell::EffectLeap(SpellEffIndex effIndex)
     if (!m_targets.HasDst())
         return;
 
-    Position pos;
+    Position pos = destTarget->GetPosition();
     unitTarget->NearTeleportTo(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), pos.GetOrientation(), unitTarget == m_caster);
 }
 


### PR DESCRIPTION
The default position was always (0, 0, 0). This fixes spells like blink to teleport to the proper destination.