### PR TITLE
[Core/Questing] Fix reverse quest relations and SMSG_QUEST_NPC_QUERY_RESPONSE

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -7752,7 +7752,7 @@ void ObjectMgr::DeleteCorpseCellData(uint32 mapid, uint32 cellid, uint32 player_
     cell_guids.corpses.erase(player_guid);
 }
 
-void ObjectMgr::LoadQuestRelationsHelper(QuestRelations& map, std::string const& table, bool starter, bool go)
+void ObjectMgr::LoadQuestRelationsHelper(QuestRelations& map, QuestRelationsReverse* reversedMap, std::string const& table, bool starter, bool go)
 {
     uint32 oldMSTime = getMSTime();
 
@@ -7789,6 +7789,9 @@ void ObjectMgr::LoadQuestRelationsHelper(QuestRelations& map, std::string const&
         else if (starter)
             poolRelationMap->insert(PooledQuestRelation::value_type(quest, id));
 
+        if (reversedMap)
+            reversedMap->insert(QuestRelationsReverse::value_type(quest, id));
+
         ++count;
     } while (result->NextRow());
 
@@ -7797,7 +7800,7 @@ void ObjectMgr::LoadQuestRelationsHelper(QuestRelations& map, std::string const&
 
 void ObjectMgr::LoadGameobjectQuestStarters()
 {
-    LoadQuestRelationsHelper(_goQuestRelations, "gameobject_queststarter", true, true);
+    LoadQuestRelationsHelper(_goQuestRelations, nullptr, "gameobject_queststarter", true, true);
 
     for (QuestRelations::iterator itr = _goQuestRelations.begin(); itr != _goQuestRelations.end(); ++itr)
     {
@@ -7811,7 +7814,7 @@ void ObjectMgr::LoadGameobjectQuestStarters()
 
 void ObjectMgr::LoadGameobjectQuestEnders()
 {
-    LoadQuestRelationsHelper(_goQuestInvolvedRelations, "gameobject_questender", false, true);
+    LoadQuestRelationsHelper(_goQuestInvolvedRelations, &_goQuestInvolvedRelationsReverse, "gameobject_questender", false, true);
 
     for (QuestRelations::iterator itr = _goQuestInvolvedRelations.begin(); itr != _goQuestInvolvedRelations.end(); ++itr)
     {
@@ -7825,7 +7828,7 @@ void ObjectMgr::LoadGameobjectQuestEnders()
 
 void ObjectMgr::LoadCreatureQuestStarters()
 {
-    LoadQuestRelationsHelper(_creatureQuestRelations, "creature_queststarter", true, false);
+    LoadQuestRelationsHelper(_creatureQuestRelations, nullptr, "creature_queststarter", true, false);
 
     for (QuestRelations::iterator itr = _creatureQuestRelations.begin(); itr != _creatureQuestRelations.end(); ++itr)
     {
@@ -7839,7 +7842,7 @@ void ObjectMgr::LoadCreatureQuestStarters()
 
 void ObjectMgr::LoadCreatureQuestEnders()
 {
-    LoadQuestRelationsHelper(_creatureQuestInvolvedRelations, "creature_questender", false, false);
+    LoadQuestRelationsHelper(_creatureQuestInvolvedRelations, &_creatureQuestInvolvedRelationsReverse, "creature_questender", false, false);
 
     for (QuestRelations::iterator itr = _creatureQuestInvolvedRelations.begin(); itr != _creatureQuestInvolvedRelations.end(); ++itr)
     {

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -1862,7 +1862,7 @@ class ObjectMgr
 
     private:
         void LoadScripts(ScriptsType type);
-        void LoadQuestRelationsHelper(QuestRelations& map, std::string const& table, bool starter, bool go);
+        void LoadQuestRelationsHelper(QuestRelations& map, QuestRelationsReverse* reversedMap, std::string const& table, bool starter, bool go);
         void PlayerCreateInfoAddItemHelper(uint32 race_, uint32 class_, uint32 itemId, int32 count);
 
         MailLevelRewardContainer _mailLevelRewardStore;

--- a/src/server/game/Handlers/QueryHandler.cpp
+++ b/src/server/game/Handlers/QueryHandler.cpp
@@ -704,17 +704,16 @@ void WorldSession::HandleQuestNPCQuery(WorldPacket& recvData)
         uint32 questId;
         recvData >> questId;
 
-        /// @todo verify if we should only send completed quests questgivers
-        if (sObjectMgr->GetQuestTemplate(questId) && _player->GetQuestStatus(questId) == QUEST_STATUS_COMPLETE)
-        {
-            auto creatures = sObjectMgr->GetCreatureQuestInvolvedRelationReverseBounds(questId);
-            for (auto it = creatures.first; it != creatures.second; ++it)
-                quests[questId].push_back(it->second);
+        if (!sObjectMgr->GetQuestTemplate(questId))
+            continue;
 
-            auto gos = sObjectMgr->GetGOQuestInvolvedRelationReverseBounds(questId);
-            for (auto it = gos.first; it != gos.second; ++it)
-                quests[questId].push_back(it->second | 0x80000000); // GO mask
-        }
+        auto creatures = sObjectMgr->GetCreatureQuestInvolvedRelationReverseBounds(questId);
+        for (auto it = creatures.first; it != creatures.second; ++it)
+            quests[questId].push_back(it->second);
+
+        auto gos = sObjectMgr->GetGOQuestInvolvedRelationReverseBounds(questId);
+        for (auto it = gos.first; it != gos.second; ++it)
+            quests[questId].push_back(it->second | 0x80000000); // GO mask
     }
 
     uint32 count;


### PR DESCRIPTION
This fixes quest completion icons in the minimap; reverse quest relations were never populated so the `SMSG_QUEST_NPC_QUERY_RESPONSE` message was always empty.

Original bug:

1. Create new blood elf
2. Zoom minimap all the way in (`+`)
3. Accept first quest
4. `.quest complete 8325`
5. See 2x quest completion icons in the minimap:

![quest-completion-two-icons](https://github.com/Legends-of-Azeroth/Legends-of-Azeroth-Pandaria-5.4.8/assets/1695733/97568e8e-645d-4156-b46d-7136dd890e98)

Fixed with this PR:

1. Create new blood elf
2. Zoom minimap all the way in (`+`)
3. Accept first quest
4. `.quest complete 8325`
5. See 1x quest completion icon in the minimap:

![quest-completion-one-icon](https://github.com/Legends-of-Azeroth/Legends-of-Azeroth-Pandaria-5.4.8/assets/1695733/b73b5efc-b3fe-45aa-bb54-3f155e36fa59)
