### PR TITLE
[Core/Resting] set rest flag in faction area

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7865,6 +7865,12 @@ void Player::UpdateArea(uint32 newArea)
 
     phaseMgr.RemoveUpdateFlag(PHASE_UPDATE_FLAG_AREA_UPDATE);
 
+    AreaFlags const areaRestFlag = (GetTeam() == ALLIANCE) ? AREA_FLAG_ALLIANCE_RESTING : AREA_FLAG_HORDE_RESTING;
+    if (area && area->Flags & areaRestFlag)
+        SetRestFlag(REST_FLAG_IN_FACTION_AREA);
+    else
+        RemoveRestFlag(REST_FLAG_IN_FACTION_AREA);
+
     if (GetGroup())
         SetGroupUpdateFlag(GROUP_UPDATE_FLAG_AREA | GROUP_UPDATE_FLAG_PHASE);
 }

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -801,9 +801,10 @@ class InstanceSave;
 
 enum RestFlag
 {
-    REST_FLAG_NONE = 0,
-    REST_FLAG_IN_TAVERN = 1,
-    REST_FLAG_IN_CITY = 2
+    REST_FLAG_NONE            = 0,
+    REST_FLAG_IN_TAVERN       = 1,
+    REST_FLAG_IN_CITY         = 2,
+    REST_FLAG_IN_FACTION_AREA = 4
 };
 
 enum TeleportToOptions

--- a/src/server/shared/DataStores/DBCEnums.h
+++ b/src/server/shared/DataStores/DBCEnums.h
@@ -394,8 +394,8 @@ enum AreaFlags
     AREA_FLAG_UNK6             = 0x00080000,                // Valgarde and Acherus: The Ebon Hold
     AREA_FLAG_LOWLEVEL         = 0x00100000,                // used for some starting areas with area_level <= 15
     AREA_FLAG_TOWN             = 0x00200000,                // small towns with Inn
-    AREA_FLAG_UNK7             = 0x00400000,                // Warsong Hold, Acherus: The Ebon Hold, New Agamand Inn, Vengeance Landing Inn, Sunreaver Pavilion (Something to do with team?)
-    AREA_FLAG_UNK8             = 0x00800000,                // Valgarde, Acherus: The Ebon Hold, Westguard Inn, Silver Covenant Pavilion (Something to do with team?)
+    AREA_FLAG_HORDE_RESTING    = 0x00400000,                // Warsong Hold, Acherus: The Ebon Hold, New Agamand Inn, Vengeance Landing Inn, Sunreaver Pavilion (Something to do with team?)
+    AREA_FLAG_ALLIANCE_RESTING = 0x00800000,                // Valgarde, Acherus: The Ebon Hold, Westguard Inn, Silver Covenant Pavilion (Something to do with team?)
     AREA_FLAG_WINTERGRASP      = 0x01000000,                // Wintergrasp and it's subzones
     AREA_FLAG_INSIDE           = 0x02000000,                // used for determinating spell related inside/outside questions in Map::IsOutdoors
     AREA_FLAG_OUTSIDE          = 0x04000000,                // used for determinating spell related inside/outside questions in Map::IsOutdoors


### PR DESCRIPTION
This fixes resting in faction areas that do not use the area trigger system.

Test Alliance rest areas:
  - `.tele valgarde` and walk into closest building, verify rested
  - Make a new DK and verify rested in Acherus: The Ebon Hold

Test Horde rest areas:
  - `.tele falconwingsq` and walk into building with curtains, verify rested
  - Make a new DK and verify rested in Acherus: The Ebon Hold