### PR TITLE
[Core/Player] Add DB table playercreateinfo_cast_spell

### DIFF
--- a/sql/updates/master/world/2024_06_27_00_world.sql
+++ b/sql/updates/master/world/2024_06_27_00_world.sql
@@ -1,0 +1,56 @@
+-- Gnome - Irradiated, should be cast on player create, not on area
+delete from spell_area where spell = 80653 and area = 5495;
+
+--
+-- Table structure for table `playercreateinfo_cast_spell`
+--
+
+DROP TABLE IF EXISTS `playercreateinfo_cast_spell`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `playercreateinfo_cast_spell` (
+   `raceMask` bigint unsigned NOT NULL,
+   `classMask` int unsigned NOT NULL DEFAULT '0',
+   `spell` int unsigned NOT NULL DEFAULT '0',
+   `note` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+   PRIMARY KEY (`raceMask`,`classMask`,`spell`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+insert into playercreateinfo_cast_spell (raceMask, classMask, spell, note)
+values  (0, 32, 48266, 'Death Knight - Frost Presence'),
+        (0, 1, 2457, 'Warrior - Battle Stance'),
+        (1, 4, 79597, 'Human - Hunter - Young Wolf'),
+        (2, 4, 79598, 'Orc - Hunter - Young Boar'),
+        (4, 4, 79593, 'Dwarf - Hunter - Young Boar'),
+        (8, 4, 79602, 'Night Elf - Hunter - Young Cat'),
+        (16, 4, 79600, 'Undead - Hunter - Young Widow'),
+        (32, 4, 79603, 'Tauren - Hunter - Young Tallstrider'),
+        (128, 4, 79599, 'Troll - Hunter - Young Raptor'),
+        (256, 4, 79595, 'Goblin - Hunter - Young Crab'),
+        (512, 4, 79594, 'Blood Elf - Hunter - Young Dragonhawk'),
+        (1024, 4, 79601, 'Draenei - Hunter - Young Moth'),
+        (2097152, 4, 79596, 'Worgen - Hunter - Young Mastiff'),
+        (8388608, 4, 107924, 'Pandaren - Hunter - Wise Turtle'),
+        (0, 256, 688, 'Warlock - Summon Imp'),
+        (16, 925, 73523, 'Undead - Rigor Mortis'),
+        (64, 256, 80653, 'Warlock - Gnome - Irradiated Aura'),
+        (64, 128, 80653, 'Mage - Gnome - Irradiated Aura'),
+        (64, 16, 80653, 'Priest - Gnome - Irradiated Aura'),
+        (64, 8, 80653, 'Rogue - Gnome - Irradiated Aura'),
+        (64, 1, 80653, 'Warrior - Gnome - Irradiated Aura'),
+        (64, 512, 80653, 'Monk - Gnome - Irradiated Aura'),
+        (8388608, 1, 108059, 'Pandaren - Warrior - Remove weapon'),
+        (8388608, 4, 108061, 'Pandaren - Hunter - Remove weapon'),
+        (8388608, 8, 108058, 'Pandaren - Rogue - Remove weapon'),
+        (8388608, 16, 108057, 'Pandaren - Priest - Remove weapon'),
+        (8388608, 64, 108056, 'Pandaren - Shaman - Remove weapon'),
+        (8388608, 384, 108055, 'Pandaren - Mage - Remove weapon'),
+        (8388608, 512, 108060, 'Pandaren - Monk - Remove weapon'),
+        (8388608, 1, 107922, 'Pandaren - Warrior - Starting quest'),
+        (8388608, 4, 107917, 'Pandaren - Hunter - Starting quest'),
+        (8388608, 8, 107920, 'Pandaren - Rogue - Starting quest'),
+        (8388608, 16, 107919, 'Pandaren - Priest - Starting quest'),
+        (8388608, 64, 107921, 'Pandaren - Shaman - Starting quest'),
+        (8388608, 384, 107916, 'Pandaren - Mage - Starting quest'),
+        (8388608, 512, 107915, 'Pandaren - Monk - Starting quest');

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -3789,6 +3789,60 @@ void ObjectMgr::LoadPlayerInfo()
     //     }
     // }
 
+    TC_LOG_INFO("server.loading", "Loading Player Create Cast Spell Data...");
+    {
+        uint32 oldMSTime = getMSTime();
+
+        QueryResult result = WorldDatabase.PQuery("SELECT raceMask, classMask, spell FROM playercreateinfo_cast_spell");
+
+        if (!result)
+            TC_LOG_INFO("server.loading", ">> Loaded 0 player create cast spells. DB table `playercreateinfo_cast_spell` is empty.");
+        else
+        {
+            uint32 count = 0;
+
+            do
+            {
+                Field* fields = result->Fetch();
+                uint64 raceMask = fields[0].GetUInt64();
+                uint32 classMask = fields[1].GetUInt32();
+                uint32 spellId = fields[2].GetUInt32();
+
+                if (raceMask != 0 && !(raceMask & RACEMASK_ALL_PLAYABLE))
+                {
+                    TC_LOG_ERROR("sql.sql", "Wrong race mask %u in `playercreateinfo_cast_spell` table, ignoring.", raceMask);
+                    continue;
+                }
+
+                if (classMask != 0 && !(classMask & CLASSMASK_ALL_PLAYABLE))
+                {
+                    TC_LOG_ERROR("sql.sql", "Wrong class mask %u in `playercreateinfo_cast_spell` table, ignoring.", classMask);
+                    continue;
+                }
+
+                for (uint32 raceIndex = RACE_HUMAN; raceIndex < MAX_RACES; ++raceIndex)
+                {
+                    if (raceMask == 0 || ((1 << (raceIndex - 1)) & raceMask))
+                    {
+                        for (uint32 classIndex = CLASS_WARRIOR; classIndex < MAX_CLASSES; ++classIndex)
+                        {
+                            if (classMask == 0 || ((1 << (classIndex - 1)) & classMask))
+                            {
+                                if (PlayerInfo* info = _playerInfo[raceIndex][classIndex])
+                                {
+                                    info->castSpells.push_back(spellId);
+                                    ++count;
+                                }
+                            }
+                        }
+                    }
+                }
+            }  while (result->NextRow());
+            
+            TC_LOG_INFO("server.loading", ">> Loaded %u player create cast spells in %u ms", count, GetMSTimeDiffToNow(oldMSTime));
+        }
+    }
+
     // Loading levels data (class/race dependent)
     TC_LOG_INFO("server.loading", "Loading Player Create Level Stats Data...");
     {

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -676,6 +676,8 @@ typedef std::vector<PlayerCreateInfoSkill> PlayerCreateInfoSkills;
 
 typedef std::list<uint32> PlayerCreateSkillRaceClassList;
 
+typedef std::vector<uint32> PlayerCreateInfoSpells;
+
 struct PlayerCreateInfoAction
 {
     PlayerCreateInfoAction() : button(0), type(0), action(0)
@@ -705,6 +707,7 @@ struct PlayerInfo
     uint16 displayId_m;
     uint16 displayId_f;
     PlayerCreateInfoItems item;
+    PlayerCreateInfoSpells castSpells;
     //PlayerCreateInfoSkills skills;      // Not skill id - index from SkillRaceClassInfo.dbc 
     PlayerCreateSkillRaceClassList skills;
     PlayerCreateInfoActions action;

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -1185,59 +1185,9 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder const& holder)
     {
         pCurrChar->RemoveAtLoginFlag(AT_LOGIN_FIRST);
 
-        if (pCurrChar->GetClass() == CLASS_HUNTER)
-        {
-            static uint32 const HunterCreatePetSpells[MAX_RACES] =
-            {
-                0,      /* None */                          79597,  /* Human - Young Wolf */
-                79598,  /* Orc - Young Boar */              79593,  /* Dwarf - Young Bear */
-                79602,  /* Night Elf - Young Cat */         79600,  /* Undead - Young Widow */
-                79603,  /* Tauren - Young Tallstrider */    0,      /* Gnome */
-                79599,  /* Troll - Young Raptor */          79595,  /* Goblin - Young Crab */
-                79594,  /* Blood Elf - Young Dragonhawk */  79601,  /* Draenei - Young Moth */
-                0,      /* Fel Orc */                       0,      /* Naga */
-                0,      /* Broken */                        0,      /* Skeleton */
-                0,      /* Vrykul */                        0,      /* Tuskarr */
-                0,      /* Forest Troll */                  0,      /* Taunka */
-                0,      /* Northrend Skeleton */            0,      /* Ice Troll */
-                79596,  /* Worgen - Young Mastiff */        0,      /* Gilnean */
-                107924, /* Pandaren - Wise Turtle */        0,      /* Pandaren Alliance */
-                0       /* Pandaren Horde*/
-            };
-
-            pCurrChar->CastSpell(pCurrChar, HunterCreatePetSpells[pCurrChar->GetRace()], true);
-        }
-
-        if (pCurrChar->GetRace() == RACE_UNDEAD_PLAYER && pCurrChar->GetClass() != CLASS_DEATH_KNIGHT)
-            pCurrChar->CastSpell(pCurrChar, 73523, true); // Undead - Rigor Mortis
-
-        if (pCurrChar->GetRace() == RACE_PANDAREN_NEUTRAL)
-        {
-            static uint32 const PandarenStartingQuestSpells[MAX_CLASSES] =
-            {
-                0,      /* None */         107922, /* Warrior */
-                0,      /* Paladin */      107917, /* Hunter */
-                107920, /* Rogue */        107919, /* Priest */
-                0,      /* Death Knight */ 107921, /* Shaman */
-                107916, /* Mage */         0,      /* Warlock */
-                107915, /* Monk */         0       /* Druid */
-            };
-
-            pCurrChar->CastSpell(pCurrChar, 100750, true); // Launch Starting Quest
-            pCurrChar->CastSpell(pCurrChar, PandarenStartingQuestSpells[pCurrChar->GetClass()], true);
-
-            static uint32 const PandarenRemoveWeaponSpells[MAX_CLASSES] =
-            {
-                0,      /* None */         108059, /* Warrior */
-                0,      /* Paladin */      108061, /* Hunter */
-                108058, /* Rogue */        108057, /* Priest */
-                0,      /* Death Knight */ 108056, /* Shaman */
-                108055, /* Mage */         0,      /* Warlock */
-                108060, /* Monk */         0       /* Druid */
-            };
-
-            pCurrChar->CastSpell(pCurrChar, PandarenRemoveWeaponSpells[pCurrChar->GetClass()], true);
-        }
+        PlayerInfo const* info = sObjectMgr->GetPlayerInfo(pCurrChar->GetRace(), pCurrChar->GetClass());
+        for (uint32 spellId : info->castSpells)
+            pCurrChar->CastSpell(pCurrChar, spellId, true);
     }
 
     if (auto servicesResult = holder.GetPreparedResult(PLAYER_LOGIN_QUERY_LOAD_SERVICES))


### PR DESCRIPTION
The custom spell casts from code were moved into a new table `playercreateinfo_cast_spell`. All of the existing spell casts were added to this table. Also:

- Fix Death Knight to activate Frost Presence on player create https://www.wowhead.com/cata/spell=48266/frost-presence
- Fix Warrior to activate Battle Stance on player create https://www.wowhead.com/cata/spell=2457/battle-stance
- Fix Gnome Irradiated Aura to use `playercreateinfo_cast_spell` instead of `spell_area` https://www.wowhead.com/cata/spell=80653/irradiated