### PR TITLE
Fix pandaren action bars

### DIFF
--- a/sql/updates/master/world/2024_06_27_01_world.sql
+++ b/sql/updates/master/world/2024_06_27_01_world.sql
@@ -1,0 +1,71 @@
+-- pandaren warrior
+-- start with action bar: attack, heroic strike, quaking palm, small rice cake
+delete from playercreateinfo_action where race = 24 and class = 1;
+insert into playercreateinfo_action (race, class, button, action, type) values
+    (24, 1, 0, 88163, 0),
+    (24, 1, 1, 78, 0),
+    (24, 1, 9, 107079, 0),
+    (24, 1, 11, 77273, 128),
+    (24, 1, 72, 88163, 0);
+
+-- pandaren hunter
+-- start with action bar: arcane shot, small sugarcane stalk, quaking palm, call pet, revive pet
+delete from playercreateinfo_action where race = 24 and class = 3;
+insert into playercreateinfo_action (race, class, button, action, type) values
+    (24, 3, 0, 3044, 0),
+    (24, 3, 7, 77272, 128),
+    (24, 3, 9, 107079, 0),
+    (24, 3, 10, 9, 48),
+    (24, 3, 11, 982, 0);
+
+-- pandaren rogue
+-- start with action bar: sinister strike, quaking palm, small sugarcane stalk
+delete from playercreateinfo_action where race = 24 and class = 4;
+insert into playercreateinfo_action (race, class, button, action, type) values
+    (24, 4, 0, 1752, 0),
+    (24, 4, 9, 107079, 0),
+    (24, 4, 11, 77272, 128);
+
+-- pandaren priest
+-- start with action bar: smite, quaking palm, small bamboo shoot
+delete from playercreateinfo_action where race = 24 and class = 5;
+insert into playercreateinfo_action (race, class, button, action, type) values
+    (24, 5, 0, 585, 0),
+    (24, 5, 9, 107079, 0),
+    (24, 5, 11, 77264, 128);
+
+-- pandaren shaman
+-- start with action bar: lightning bolt, quaking palm, small sugarcane stalk
+delete from playercreateinfo_action where race = 24 and class = 7;
+insert into playercreateinfo_action (race, class, button, action, type) values
+    (24, 7, 0, 403, 0),
+    (24, 7, 9, 107079, 0),
+    (24, 7, 11, 77272, 128),
+    (24, 7, 72, 403, 0);
+
+-- pandaren mage
+-- start with action bar: frostfire bolt, quaking palm, small bamboo shoot
+delete from playercreateinfo_action where race = 24 and class = 8;
+insert into playercreateinfo_action (race, class, button, action, type) values
+    (24, 8, 0, 44614, 0),
+    (24, 8, 9, 107079, 0),
+    (24, 8, 11, 77264, 128);
+
+-- pandaren monk
+-- start with action bar: jab, quaking palm, small sugarcane stalk
+delete from playercreateinfo_action where race = 24 and class = 10;
+insert into playercreateinfo_action (race, class, button, action, type) values
+    (24, 10, 0, 100780, 0),
+    (24, 10, 9, 107079, 0),
+    (24, 10, 11, 77272, 128),
+    (24, 10, 72, 100780, 0),
+    (24, 10, 81, 107079, 0),
+    (24, 10, 83, 77272, 128);
+
+-- pandaren monk
+-- cast stance of the fierce tiger
+delete from playercreateinfo_cast_spell where raceMask = 8388608 and classMask = 512;
+insert into playercreateinfo_cast_spell (raceMask, classMask, spell, note) values
+    (8388608, 512, 107915, 'Pandaren - Monk - Starting quest'),
+    (8388608, 512, 108060, 'Pandaren - Monk - Remove weapon'),
+    (8388608, 512, 103985, 'Pandaren - Monk - Stance of the Fierce Tiger');

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -661,15 +661,19 @@ bool Player::Create(uint32 guidlow, CharacterCreateInfo* createInfo)
     // original spells
     LearnDefaultSkills();
 
-    if (GetClass() == CLASS_MONK)
-        CastSpell(this, 103985, true); // Stance of the Fierce Tiger
-
     //if (!HasSpell(28698)) // premium menu
     //    LearnSpell(28698, false);
 
-    // original action bar
+    // Original action bar. Do not use Player::AddActionButton because we do not have skill spells loaded at this time
+    // but checks will still be performed later when loading character from db in Player::_LoadActions
     for (PlayerCreateInfoActions::const_iterator action_itr = info->action.begin(); action_itr != info->action.end(); ++action_itr)
-        addActionButton(action_itr->button, action_itr->action, action_itr->type);
+    {
+        // create new button
+        ActionButton& ab = m_actionButtons[action_itr->button];
+
+        // set data
+        ab.SetActionAndType(action_itr->action, ActionButtonType(action_itr->type));
+    }
 
     // original items
     if (CharStartOutfitEntry const* oEntry = GetCharStartOutfitEntry(createInfo->Race, createInfo->Class, createInfo->Gender))
@@ -6622,7 +6626,7 @@ bool Player::IsActionButtonDataValid(uint8 button, uint32 action, uint8 type)
     return true;
 }
 
-ActionButton* Player::addActionButton(uint8 button, uint32 action, uint8 type)
+ActionButton* Player::AddActionButton(uint8 button, uint32 action, uint8 type)
 {
     if (!IsActionButtonDataValid(button, action, type))
         return nullptr;
@@ -6637,7 +6641,7 @@ ActionButton* Player::addActionButton(uint8 button, uint32 action, uint8 type)
     return &ab;
 }
 
-void Player::removeActionButton(uint8 button)
+void Player::RemoveActionButton(uint8 button)
 {
     ActionButtonList::iterator buttonItr = m_actionButtons.find(button);
     if (buttonItr == m_actionButtons.end() || buttonItr->second.uState == ACTIONBUTTON_DELETED)
@@ -19334,7 +19338,7 @@ void Player::_LoadActions(PreparedQueryResult result)
             uint32 action = fields[1].GetUInt32();
             uint8 type = fields[2].GetUInt8();
 
-            if (ActionButton* ab = addActionButton(button, action, type))
+            if (ActionButton* ab = AddActionButton(button, action, type))
                 ab->uState = ACTIONBUTTON_UNCHANGED;
             else
             {

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2145,8 +2145,8 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
     uint8 getCinematic() const { return m_cinematic; }
     void setCinematic(uint8 cine) { m_cinematic = cine; }
 
-    ActionButton* addActionButton(uint8 button, uint32 action, uint8 type);
-    void removeActionButton(uint8 button);
+    ActionButton* AddActionButton(uint8 button, uint32 action, uint8 type);
+    void RemoveActionButton(uint8 button);
     ActionButton const* GetActionButton(uint8 button);
     void SendInitialActionButtons() const
     {

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1412,9 +1412,9 @@ void WorldSession::HandleSetActionButtonOpcode(WorldPacket& recvData)
     TC_LOG_DEBUG("network", "CMSG_SET_ACTION_BUTTON slotId: %u actionId: %u", slotId, button->id);
 
     if (!button->id)
-        GetPlayer()->removeActionButton(slotId);
+        GetPlayer()->RemoveActionButton(slotId);
     else
-        GetPlayer()->addActionButton(slotId, button->id, button->type);
+        GetPlayer()->AddActionButton(slotId, button->id, button->type);
 }
 
 void WorldSession::HandleCompleteCinematic(WorldPacket& /*recvData*/)

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -553,9 +553,6 @@ void WorldSession::LogoutPlayer(bool save)
             _player->SetPendingBind(0, 0);
         }
 
-        if (_player->HasAuraType(SPELL_AURA_MOD_SPEED_ALWAYS))
-            _player->RemoveAurasByType(SPELL_AURA_MOD_SPEED_ALWAYS);
-
         //drop a flag if player is carrying it
         if (Battleground* bg = _player->GetBattleground())
             bg->EventPlayerLoggedOut(_player);

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1379,9 +1379,25 @@ bool Aura::CanBeSaved() const
     if (IsPassive())
         return false;
 
+    if (GetSpellInfo()->IsChanneled())
+        return false;
+
+    // Check if aura is single target, not only spell info
     if (GetCasterGUID() != GetOwner()->GetGUID())
+    {
+        for (SpellEffectInfo const& spellEffectInfo : GetSpellInfo()->GetEffects())
+        {
+            if (!spellEffectInfo.IsEffect())
+                continue;
+
+            if (spellEffectInfo.IsTargetingArea() || spellEffectInfo.IsAreaAuraEffect())
+                return false;
+        }
+
+        // TODO: if (IsSingleTarget() || GetSpellInfo()->IsSingleTarget())
         if (GetSpellInfo()->IsSingleTarget())
             return false;
+    }
 
     // Can't be saved - aura handler relies on calculated amount and changes it
     if (HasEffectType(SPELL_AURA_CONVERT_RUNE))


### PR DESCRIPTION
This configures Pandaren action bars for all classes.

It also casts `Stance of the Fierce Tiger` https://www.wowhead.com/spell=103985/stance-of-the-fierce-tiger on Pandaren Monk player create, and fixes the core so this stance is not removed on logout.