### PR TITLE
[Core/PacketIO] Fix login with certain addons

### DIFF
--- a/src/common/Threading/LockedQueue.h
+++ b/src/common/Threading/LockedQueue.h
@@ -56,6 +56,16 @@ public:
         unlock();
     }
 
+    //! Adds an item to front of the queue
+    void push_front(const T& item)
+    {
+        lock();
+
+        _queue.push_front(item);
+
+        unlock();
+    }
+
     //! Adds items back to front of the queue
     template<class Iterator>
     void readd(Iterator begin, Iterator end)

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -260,7 +260,13 @@ void WorldSession::SendPacket(WorldPacket const* packet, bool forced /*= false*/
 /// Add an incoming packet to the queue
 void WorldSession::QueuePacket(WorldPacket* new_packet)
 {
-    _recvQueue.add(new_packet);
+    // prioritize CMSG_PLAYER_LOGIN
+    // sometimes CMSG_PLAYER_LOGIN arrives after hundreds of packets that require STATUS_LOGGEDIN
+    // if CMSG_PLAYER_LOGIN is not prioritized, login will never complete
+    if (!_player && new_packet->GetOpcode() == CMSG_PLAYER_LOGIN)
+        _recvQueue.push_front(new_packet);
+    else
+        _recvQueue.add(new_packet);
 }
 
 /// Logging helper for unexpected opcodes


### PR DESCRIPTION
This allows addons like TradeSkillMaster and ElvUI to work with this core. Without this change, the loading bar stops at 90% and the server loops on the same 100 messages forever, never logging in the client.