### PR TITLE
Fix failing windows PR checks

### DIFF
--- a/.github/workflows/windows-build-release.yml
+++ b/.github/workflows/windows-build-release.yml
@@ -1,10 +1,10 @@
-name: windows-build
+name: windows-build-release
 
 on:
-  pull_request:
+  push:
     paths-ignore:
-      - 'sql/**'
-      
+      - 'sql/**'    
+
 concurrency:
   group: ${{ github.head_ref }} || concat(${{ github.ref }}, ${{ github.workflow }})
   cancel-in-progress: true
@@ -71,3 +71,40 @@ jobs:
         cmake --build . --config RelWithDebInfo --parallel 4
       #git bash shell
       shell: bash
+    - name: Create Upload File Name
+      run: |
+          echo "ARCHIVE_FILENAME=${{ github.event.repository.name }}-$(git rev-parse --short HEAD).zip" >> $env:GITHUB_ENV
+    - name: Archive files
+      run: |
+          #data is in Release folder
+          cd ${{github.workspace}}/build/bin
+          dir
+          copy "C:/Program Files/MySQL/MySQL Server 5.7/lib/libmysql.dll" ${{github.workspace}}/build/bin/RelWithDebInfo/libmysql.dll
+          copy "C:/Program Files/OpenSSL/bin/libssl-1_1-x64.dll" ${{github.workspace}}/build/bin/RelWithDebInfo/libssl-1_1-x64.dll
+          copy "c:/Program Files/OpenSSL/bin/libcrypto-1_1-x64.dll" ${{github.workspace}}/build/bin/RelWithDebInfo/libcrypto-1_1-x64.dll
+          move ${{github.workspace}}/contrib/lua_scripts ${{github.workspace}}/build/bin/RelWithDebInfo/lua_scripts
+          7z a -tzip ${{env.ARCHIVE_FILENAME}} RelWithDebInfo
+    - name: Archive this artefact
+      uses: actions/upload-artifact@v2
+      with:
+          name: snapshot-devbuild
+          path: "${{github.workspace}}/build/bin/${{env.ARCHIVE_FILENAME}}"
+
+    - name: Download artifact snapshot-Release
+      uses: actions/download-artifact@v1
+      with:
+        name: snapshot-devbuild
+        path: all_snapshots
+
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+    - name: Upload snapshot
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "Development Build(${{ steps.date.outputs.date }})"
+        files: all_snapshots


### PR DESCRIPTION
I copied and edited the `windows-build` workflow; now there are two:

`windows-build`:
  - only runs on PR
  - only builds; does not publish

`windows-build-release`:
  - does not run on PR
  - only runs on push
  - builds and publishes

This should allow PRs to pass their status checks.