### PR TITLE
[Core/PacketIO] Add game object query packets

### DIFF
--- a/src/server/game/Server/Packets/AllPackets.h
+++ b/src/server/game/Server/Packets/AllPackets.h
@@ -20,6 +20,7 @@
 
 #include "CharacterPackets.h"
 #include "MiscPackets.h"
+#include "QueryPackets.h"
 #include "QuestPackets.h"
 
 #endif // AllPackets_h__

--- a/src/server/game/Server/Packets/QueryPackets.cpp
+++ b/src/server/game/Server/Packets/QueryPackets.cpp
@@ -1,0 +1,79 @@
+/*
+* This file is part of the Legends of Azeroth Pandaria Project. See THANKS file for Copyright information
+*
+* This program is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the
+* Free Software Foundation; either version 2 of the License, or (at your
+* option) any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "QueryPackets.h"
+
+void WorldPackets::Query::QueryGameObject::Read()
+{
+    _worldPacket >> GameObjectID;
+
+    Guid[5] = _worldPacket.ReadBit();
+    Guid[3] = _worldPacket.ReadBit();
+    Guid[6] = _worldPacket.ReadBit();
+    Guid[2] = _worldPacket.ReadBit();
+    Guid[7] = _worldPacket.ReadBit();
+    Guid[1] = _worldPacket.ReadBit();
+    Guid[0] = _worldPacket.ReadBit();
+    Guid[4] = _worldPacket.ReadBit();
+
+    _worldPacket.ReadByteSeq(Guid[1]);
+    _worldPacket.ReadByteSeq(Guid[5]);
+    _worldPacket.ReadByteSeq(Guid[3]);
+    _worldPacket.ReadByteSeq(Guid[4]);
+    _worldPacket.ReadByteSeq(Guid[6]);
+    _worldPacket.ReadByteSeq(Guid[2]);
+    _worldPacket.ReadByteSeq(Guid[7]);
+    _worldPacket.ReadByteSeq(Guid[0]);
+}
+
+WorldPacket const* WorldPackets::Query::QueryGameObjectResponse::Write()
+{
+    _worldPacket.WriteBit(Allow);
+    _worldPacket << GameObjectID;
+    _worldPacket.FlushBits();
+
+    if (Allow)
+    {
+        uint32 dataSize = Stats.GetDataSize();
+
+        _worldPacket << uint32(dataSize);
+        if (dataSize)
+        {
+            _worldPacket << Stats.Type;
+            _worldPacket << Stats.DisplayID;
+            for (int8 i = 0; i < 4; i++)
+                _worldPacket << Stats.Name[i];
+
+            _worldPacket << Stats.IconName;
+            _worldPacket << Stats.CastBarCaption;
+            _worldPacket << Stats.UnkString;
+
+            for (uint32 i = 0; i < MAX_GAMEOBJECT_DATA; i++)
+                _worldPacket << Stats.Data[i];
+
+            _worldPacket << Stats.Size;
+
+            _worldPacket << uint8(Stats.QuestItems.size());
+            for (uint32 questItem : Stats.QuestItems)
+                _worldPacket << questItem;
+
+            _worldPacket << Stats.UnkInt32;
+        }
+    }
+
+    return &_worldPacket;
+}

--- a/src/server/game/Server/Packets/QueryPackets.h
+++ b/src/server/game/Server/Packets/QueryPackets.h
@@ -1,0 +1,74 @@
+/*
+* This file is part of the Legends of Azeroth Pandaria Project. See THANKS file for Copyright information
+*
+* This program is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the
+* Free Software Foundation; either version 2 of the License, or (at your
+* option) any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef QueryPackets_h__
+#define QueryPackets_h__
+
+#include "Packet.h"
+#include "ObjectGuid.h"
+#include "SharedDefines.h"
+
+namespace WorldPackets
+{
+    namespace Query
+    {
+        class QueryGameObject final : public ClientPacket
+        {
+        public:
+            QueryGameObject(WorldPacket&& packet) : ClientPacket(CMSG_GAMEOBJECT_QUERY, std::move(packet)) { }
+
+            void Read() override;
+
+            ObjectGuid Guid;
+            uint32 GameObjectID = 0;
+        };
+
+        struct GameObjectStats
+        {
+            std::string Name[4];
+            std::string IconName;
+            std::string CastBarCaption;
+            std::string UnkString;
+            uint32 Type = 0;
+            uint32 DisplayID = 0;
+            std::array<uint32, MAX_GAMEOBJECT_DATA> Data = { };
+            float Size = 0.0f;
+            std::vector<uint32> QuestItems;
+            uint32 UnkInt32 = 0;
+
+            size_t GetDataSize() const
+            {
+                //                                         [1..3] always empty '\0'                     '\0'                          '\0'                     '\0'                                 QuestItems counter
+                return sizeof(Type) + sizeof(DisplayID) + (Name->size() + (4 * 1)) + (IconName.size() + 1) + (CastBarCaption.size() + 1) + (UnkString.size() + 1) + sizeof(Data) + sizeof(Size) + sizeof(uint8) + (QuestItems.size() * sizeof(uint32)) + sizeof(UnkInt32);
+            }
+        };
+
+        class QueryGameObjectResponse final : public ServerPacket
+        {
+        public:
+            QueryGameObjectResponse() : ServerPacket(SMSG_GAMEOBJECT_QUERY_RESPONSE, 165) { }
+
+            WorldPacket const* Write() override;
+
+            uint32 GameObjectID = 0;
+            bool Allow = false;
+            GameObjectStats Stats;
+        };
+    }
+}
+
+#endif

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -607,7 +607,7 @@ class TC_GAME_API WorldSession
 
         void HandleCreatureQueryOpcode(WorldPacket& recvPacket);
 
-        void HandleGameObjectQueryOpcode(WorldPacket& recvPacket);
+        void HandleGameObjectQueryOpcode(WorldPackets::Query::QueryGameObject& packet);
 
         void HandleMoveWorldportAckOpcode(WorldPacket& recvPacket);
         void HandleMoveWorldportAck();


### PR DESCRIPTION
This moves packet reading and writing for `CMSG_GAMEOBJECT_QUERY` and `SMSG_GAMEOBJECT_QUERY_RESPONSE` out of `QueryHandler` and into `QueryPackets`. No behavior change with this PR.

To test, empty client cache and view some game objects in the world. Locale should still be correct, etc.