### PR TITLE
[Core/PacketIO] Properly decode CMSG_PING

### DIFF
--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -1134,8 +1134,8 @@ bool WorldSocket::HandlePing(WorldPacket& recvPacket)
     uint32 latency;
 
     // Get the ping packet content
-    recvPacket >> ping;
     recvPacket >> latency;
+    recvPacket >> ping;
 
     if (_LastPingTime == steady_clock::time_point())
     {


### PR DESCRIPTION
Ping (sequence) and latency are read in the wrong order. This has a couple consequences:

1. The `SMSG_PONG` reply responds with the latency instead of the sequence, which causes `Received pong with old sequence` errors in the client console.
2. The latency set in `_worldSession->SetLatency(latency)` is incorrect

Changing the decode order fixes both of these issues, and client latency is now visible in game. Note that we still only use one connection, so latency will only display for `Home`.

This fixes #292 