### PR TITLE
[Core/Spells] Hunter auto shot improvements

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22124,7 +22124,7 @@ void Player::SendAutoRepeatCancel(Unit* target)
     data.WriteByteSeq(Guid[4]);
     data.WriteByteSeq(Guid[1]);
     data.WriteByteSeq(Guid[3]);
-    GetSession()->SendPacket(&data);
+    SendMessageToSet(&data, false);
 }
 
 void Player::SendExplorationExperience(uint32 Area, uint32 Experience)

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -325,28 +325,29 @@ enum AuraRemoveMode
 
 enum TriggerCastFlags
 {
-    TRIGGERED_NONE = 0x00000000,   //! Not triggered
-    TRIGGERED_IGNORE_GCD = 0x00000001,   //! Will ignore GCD
-    TRIGGERED_IGNORE_SPELL_AND_CATEGORY_CD = 0x00000002,   //! Will ignore Spell and Category cooldowns
-    TRIGGERED_IGNORE_POWER_AND_REAGENT_COST = 0x00000004,   //! Will ignore power and reagent cost
-    TRIGGERED_IGNORE_CAST_ITEM = 0x00000008,   //! Will not take away cast item or update related achievement criteria
-    TRIGGERED_IGNORE_AURA_SCALING = 0x00000010,   //! Will ignore aura scaling
-    TRIGGERED_IGNORE_CAST_IN_PROGRESS = 0x00000020,   //! Will not check if a current cast is in progress
-    TRIGGERED_IGNORE_COMBO_POINTS = 0x00000040,   //! Will ignore combo point requirement
-    TRIGGERED_CAST_DIRECTLY = 0x00000080,   //! In Spell::prepare, will be cast directly without setting containers for executed spell
-    TRIGGERED_IGNORE_AURA_INTERRUPT_FLAGS = 0x00000100,   //! Will ignore interruptible aura's at cast
-    TRIGGERED_IGNORE_SET_FACING = 0x00000200,   //! Will not adjust facing to target (if any)
-    TRIGGERED_IGNORE_SHAPESHIFT = 0x00000400,   //! Will ignore shapeshift checks
-    TRIGGERED_IGNORE_CASTER_AURASTATE = 0x00000800,   //! Will ignore caster aura states including combat requirements and death state
+    TRIGGERED_NONE                                = 0x00000000,   //! Not triggered
+    TRIGGERED_IGNORE_GCD                          = 0x00000001,   //! Will ignore GCD
+    TRIGGERED_IGNORE_SPELL_AND_CATEGORY_CD        = 0x00000002,   //! Will ignore Spell and Category cooldowns
+    TRIGGERED_IGNORE_POWER_AND_REAGENT_COST       = 0x00000004,   //! Will ignore power and reagent cost
+    TRIGGERED_IGNORE_CAST_ITEM                    = 0x00000008,   //! Will not take away cast item or update related achievement criteria
+    TRIGGERED_IGNORE_AURA_SCALING                 = 0x00000010,   //! Will ignore aura scaling
+    TRIGGERED_IGNORE_CAST_IN_PROGRESS             = 0x00000020,   //! Will not check if a current cast is in progress
+    TRIGGERED_IGNORE_COMBO_POINTS                 = 0x00000040,   //! Will ignore combo point requirement
+    TRIGGERED_CAST_DIRECTLY                       = 0x00000080,   //! In Spell::prepare, will be cast directly without setting containers for executed spell
+    TRIGGERED_IGNORE_AURA_INTERRUPT_FLAGS         = 0x00000100,   //! Will ignore interruptible aura's at cast
+    TRIGGERED_IGNORE_SET_FACING                   = 0x00000200,   //! Will not adjust facing to target (if any)
+    TRIGGERED_IGNORE_SHAPESHIFT                   = 0x00000400,   //! Will ignore shapeshift checks
+    TRIGGERED_IGNORE_CASTER_AURASTATE             = 0x00000800,   //! Will ignore caster aura states including combat requirements and death state
     TRIGGERED_IGNORE_CASTER_MOUNTED_OR_ON_VEHICLE = 0x00002000,   //! Will ignore mounted/on vehicle restrictions
-    TRIGGERED_IGNORE_CASTER_AURAS = 0x00010000,   //! Will ignore caster aura restrictions or requirements
-    TRIGGERED_DISALLOW_PROC_EVENTS = 0x00020000,   //! Disallows proc events from triggered spell (default)
-    TRIGGERED_DONT_REPORT_CAST_ERROR = 0x00040000,   //! Will return SPELL_FAILED_DONT_REPORT in CheckCast functions
-    TRIGGERED_IGNORE_EQUIPPED_ITEM_REQUIREMENT = 0x00080000,   //! Will ignore equipped item requirements
-    TRIGGERED_IGNORE_TARGET_CHECK = 0x00100000,   //! Will ignore most target checks (mostly DBC target checks)
-    TRIGGERED_IGNORE_CASTER_DEATH_STATE             = 0x00200000,
-    TRIGGERED_FULL_MASK                             = 0xFFFFFFFF,
-    TRIGGERED_WITH_SPELL_START = (TRIGGERED_FULL_MASK & ~TRIGGERED_CAST_DIRECTLY),
+    TRIGGERED_IGNORE_CASTER_AURAS                 = 0x00010000,   //! Will ignore caster aura restrictions or requirements
+    TRIGGERED_DISALLOW_PROC_EVENTS                = 0x00020000,   //! Disallows proc events from triggered spell (default)
+    TRIGGERED_DONT_REPORT_CAST_ERROR              = 0x00040000,   //! Will return SPELL_FAILED_DONT_REPORT in CheckCast functions
+    TRIGGERED_FULL_MASK                           = 0x0007FFFF,   //! Used when doing CastSpell with triggered == true    TRIGGERED_IGNORE_EQUIPPED_ITEM_REQUIREMENT    = 0x00080000,   //! Will ignore equipped item requirements
+    TRIGGERED_IGNORE_EQUIPPED_ITEM_REQUIREMENT    = 0x00080000,   //! Will ignore equipped item requirements
+    TRIGGERED_IGNORE_TARGET_CHECK                 = 0x00100000,   //! Will ignore most target checks (mostly DBC target checks)
+    TRIGGERED_IGNORE_CASTER_DEATH_STATE           = 0x00200000,
+    TRIGGERED_FULL_DEBUG_MASK                     = 0xFFFFFFFF,
+    TRIGGERED_WITH_SPELL_START                    = (TRIGGERED_FULL_MASK & ~TRIGGERED_CAST_DIRECTLY),
 };
 
 enum UnitMods
@@ -2638,8 +2639,6 @@ protected:
     void _DeleteRemovedAuras();
 
     void _UpdateAutoRepeatSpell();
-
-    bool m_AutoRepeatFirstCast;
 
     uint32 m_attackTimer[MAX_ATTACK];
     uint32 m_attackTimerReminder[MAX_ATTACK];

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -350,35 +350,35 @@ void Spell::EffectInstaKill(SpellEffIndex /*effIndex*/)
     data.WriteBit(casterguid[7]);
     data.WriteBit(targetguid[2]);
     data.WriteBit(casterguid[3]);
-data.WriteBit(casterguid[1]);
-data.WriteBit(casterguid[2]);
-data.WriteBit(casterguid[0]);
-data.WriteBit(casterguid[4]);
+    data.WriteBit(casterguid[1]);
+    data.WriteBit(casterguid[2]);
+    data.WriteBit(casterguid[0]);
+    data.WriteBit(casterguid[4]);
     data.WriteBit(targetguid[4]);
-data.WriteBit(targetguid[7]);
-data.WriteBit(targetguid[1]);
-data.WriteBit(targetguid[6]);
-data.WriteBit(targetguid[5]);
+    data.WriteBit(targetguid[7]);
+    data.WriteBit(targetguid[1]);
+    data.WriteBit(targetguid[6]);
+    data.WriteBit(targetguid[5]);
     data.WriteBit(casterguid[5]);
     data.WriteBit(targetguid[3]);
 
     data.WriteByteSeq(casterguid[0]);
     data.WriteByteSeq(targetguid[1]);
     data.WriteByteSeq(casterguid[3]);
-data.WriteByteSeq(casterguid[4]);
-data.WriteByteSeq(casterguid[5]);
-data.WriteByteSeq(casterguid[7]);
+    data.WriteByteSeq(casterguid[4]);
+    data.WriteByteSeq(casterguid[5]);
+    data.WriteByteSeq(casterguid[7]);
     data.WriteByteSeq(targetguid[0]);
     data.WriteByteSeq(casterguid[6]);
     data.WriteByteSeq(targetguid[2]);
-data.WriteByteSeq(targetguid[4]);
+    data.WriteByteSeq(targetguid[4]);
     data.WriteByteSeq(casterguid[1]);
     data << int32(m_spellInfo->Id);
     data.WriteByteSeq(targetguid[3]);
     data.WriteByteSeq(casterguid[2]);
     data.WriteByteSeq(targetguid[7]);
-data.WriteByteSeq(targetguid[6]);
-data.WriteByteSeq(targetguid[5]);
+    data.WriteByteSeq(targetguid[6]);
+    data.WriteByteSeq(targetguid[5]);
 
     m_caster->SendMessageToSet(&data, true);
 
@@ -2840,18 +2840,18 @@ void Spell::EffectDispel(SpellEffIndex effIndex)
         dataFail.WriteByteSeq(target[1]);
         dataFail.WriteByteSeq(caster[5]);
         dataFail.WriteByteSeq(target[2]);
-dataFail.WriteByteSeq(target[5]);
-dataFail.WriteByteSeq(target[3]);
-dataFail.WriteByteSeq(target[7]);
+        dataFail.WriteByteSeq(target[5]);
+        dataFail.WriteByteSeq(target[3]);
+        dataFail.WriteByteSeq(target[7]);
         dataFail.WriteByteSeq(caster[4]);
         dataFail.WriteByteSeq(target[4]);
         dataFail.WriteByteSeq(caster[3]);
-dataFail.WriteByteSeq(caster[0]);
-dataFail.WriteByteSeq(caster[1]);
+        dataFail.WriteByteSeq(caster[0]);
+        dataFail.WriteByteSeq(caster[1]);
         dataFail.WriteByteSeq(target[6]);
-dataFail.WriteByteSeq(target[0]);
+        dataFail.WriteByteSeq(target[0]);
         dataFail.WriteByteSeq(caster[7]);
-dataFail.WriteByteSeq(caster[6]);
+        dataFail.WriteByteSeq(caster[6]);
 
         for (auto itr : failedSpells)
             dataFail << int32(itr);
@@ -2879,10 +2879,10 @@ dataFail.WriteByteSeq(caster[6]);
     data.WriteBit(false); // is break
     data.WriteBit(false); // is steal
     data.WriteBit(target[5]);
-data.WriteBit(target[7]);
-data.WriteBit(target[4]);
-data.WriteBit(target[0]);
-data.WriteBit(target[1]);
+    data.WriteBit(target[7]);
+    data.WriteBit(target[4]);
+    data.WriteBit(target[0]);
+    data.WriteBit(target[1]);
     data.WriteBits(successList.size(), 22);
     data.WriteBit(caster[0]);
 
@@ -2894,11 +2894,11 @@ data.WriteBit(target[1]);
     }
 
     data.WriteBit(caster[3]);
-data.WriteBit(caster[2]);
+    data.WriteBit(caster[2]);
     data.WriteBit(target[3]);
     data.WriteBit(caster[1]);
-data.WriteBit(caster[7]);
-data.WriteBit(caster[6]);
+    data.WriteBit(caster[7]);
+    data.WriteBit(caster[6]);
 
     for (DispelChargesList::iterator itr = successList.begin(); itr != successList.end(); ++itr)
     {
@@ -2917,20 +2917,20 @@ data.WriteBit(caster[6]);
     data.WriteByteSeq(caster[4]);
     data.WriteByteSeq(target[3]);
     data.WriteByteSeq(caster[6]);
-data.WriteByteSeq(caster[0]);
+    data.WriteByteSeq(caster[0]);
     data.WriteByteSeq(target[5]);
-data.WriteByteSeq(target[1]);
+    data.WriteByteSeq(target[1]);
     data.WriteByteSeq(caster[3]);
-data.WriteByteSeq(caster[2]);
-data.WriteByteSeq(caster[1]);
-data.WriteByteSeq(caster[5]);
+    data.WriteByteSeq(caster[2]);
+    data.WriteByteSeq(caster[1]);
+    data.WriteByteSeq(caster[5]);
     data.WriteByteSeq(target[0]);
 
     data << uint32(m_spellInfo->Id);                // dispel spell id
 
     data.WriteByteSeq(target[7]);
-data.WriteByteSeq(target[6]);
-data.WriteByteSeq(target[2]);
+    data.WriteByteSeq(target[6]);
+    data.WriteByteSeq(target[2]);
     data.WriteByteSeq(caster[7]);
     data.WriteByteSeq(target[4]);
 
@@ -6196,18 +6196,18 @@ void Spell::EffectStealBeneficialBuff(SpellEffIndex effIndex)
         dataFail.WriteByteSeq(target[1]);
         dataFail.WriteByteSeq(caster[5]);
         dataFail.WriteByteSeq(target[2]);
-dataFail.WriteByteSeq(target[5]);
-dataFail.WriteByteSeq(target[3]);
-dataFail.WriteByteSeq(target[7]);
+        dataFail.WriteByteSeq(target[5]);
+        dataFail.WriteByteSeq(target[3]);
+        dataFail.WriteByteSeq(target[7]);
         dataFail.WriteByteSeq(caster[4]);
         dataFail.WriteByteSeq(target[4]);
         dataFail.WriteByteSeq(caster[3]);
-dataFail.WriteByteSeq(caster[0]);
-dataFail.WriteByteSeq(caster[1]);
+        dataFail.WriteByteSeq(caster[0]);
+        dataFail.WriteByteSeq(caster[1]);
         dataFail.WriteByteSeq(target[6]);
-dataFail.WriteByteSeq(target[0]);
+        dataFail.WriteByteSeq(target[0]);
         dataFail.WriteByteSeq(caster[7]);
-dataFail.WriteByteSeq(caster[6]);
+        dataFail.WriteByteSeq(caster[6]);
 
         for (auto itr : FailedSpells)
             dataFail << int32(itr);
@@ -6235,10 +6235,10 @@ dataFail.WriteByteSeq(caster[6]);
     data.WriteBit(false); // is break
     data.WriteBit(true); // is steal
     data.WriteBit(target[5]);
-data.WriteBit(target[7]);
-data.WriteBit(target[4]);
-data.WriteBit(target[0]);
-data.WriteBit(target[1]);
+    data.WriteBit(target[7]);
+    data.WriteBit(target[4]);
+    data.WriteBit(target[0]);
+    data.WriteBit(target[1]);
     data.WriteBits(success_list.size(), 22);
     data.WriteBit(caster[0]);
 
@@ -6250,11 +6250,11 @@ data.WriteBit(target[1]);
     }
 
     data.WriteBit(caster[3]);
-data.WriteBit(caster[2]);
+    data.WriteBit(caster[2]);
     data.WriteBit(target[3]);
     data.WriteBit(caster[1]);
-data.WriteBit(caster[7]);
-data.WriteBit(caster[6]);
+    data.WriteBit(caster[7]);
+    data.WriteBit(caster[6]);
 
     for (DispelList::iterator itr = success_list.begin(); itr != success_list.end(); ++itr)
     {
@@ -6273,20 +6273,20 @@ data.WriteBit(caster[6]);
     data.WriteByteSeq(caster[4]);
     data.WriteByteSeq(target[3]);
     data.WriteByteSeq(caster[6]);
-data.WriteByteSeq(caster[0]);
+    data.WriteByteSeq(caster[0]);
     data.WriteByteSeq(target[5]);
-data.WriteByteSeq(target[1]);
+    data.WriteByteSeq(target[1]);
     data.WriteByteSeq(caster[3]);
-data.WriteByteSeq(caster[2]);
-data.WriteByteSeq(caster[1]);
-data.WriteByteSeq(caster[5]);
+    data.WriteByteSeq(caster[2]);
+    data.WriteByteSeq(caster[1]);
+    data.WriteByteSeq(caster[5]);
     data.WriteByteSeq(target[0]);
 
     data << uint32(m_spellInfo->Id);                // dispel spell id
 
     data.WriteByteSeq(target[7]);
-data.WriteByteSeq(target[6]);
-data.WriteByteSeq(target[2]);
+    data.WriteByteSeq(target[6]);
+    data.WriteByteSeq(target[2]);
     data.WriteByteSeq(caster[7]);
     data.WriteByteSeq(target[4]);
 


### PR DESCRIPTION
This improves (but doesn't completely fix) auto shot for hunters.

1. Make a new hunter
2. `.char level 35`
3. Start to auto shot a creature
4. Cast feign death
5. Note the death animation is played and auto shot stops on the server

Bug that still exists after this PR:
- When the player is moved (to cancel feign death), the client still thinks the hunter is about to auto shot until ESC is pressed
