### PR TITLE
[Core/Group] Target icons server side store fix

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1820,18 +1820,18 @@ void Group::CountTheRoll(Rolls::iterator rollI)
     delete roll;
 }
 
-void Group::SetTargetIcon(uint8 id, ObjectGuid whoGuid, ObjectGuid targetGuid, uint8 Index)
+void Group::SetTargetIcon(uint8 symbol, ObjectGuid whoGuid, ObjectGuid targetGuid, uint8 partyIndex)
 {
-    if (id >= TARGETICONCOUNT)
+    if (symbol >= TARGETICONCOUNT)
         return;
 
     // clean other icons
     if (targetGuid != 0)
         for (int i=0; i<TARGETICONCOUNT; ++i)
             if (m_targetIcons[i] == targetGuid)
-                SetTargetIcon(i, ObjectGuid::Empty, ObjectGuid::Empty, 0);
+                SetTargetIcon(i, ObjectGuid::Empty, ObjectGuid::Empty, partyIndex);
 
-    m_targetIcons[id] = targetGuid;
+    m_targetIcons[symbol] = targetGuid;
 
     WorldPacket data(SMSG_RAID_TARGET_UPDATE_SINGLE, 8 + 1 + 8 + 1);
 
@@ -1854,7 +1854,7 @@ void Group::SetTargetIcon(uint8 id, ObjectGuid whoGuid, ObjectGuid targetGuid, u
 
     data.WriteByteSeq(targetGuid[1]);
 
-    data << uint8(id);
+    data << uint8(partyIndex);
 
     data.WriteByteSeq(whoGuid[0]);
     data.WriteByteSeq(whoGuid[5]);
@@ -1869,7 +1869,7 @@ void Group::SetTargetIcon(uint8 id, ObjectGuid whoGuid, ObjectGuid targetGuid, u
     data.WriteByteSeq(targetGuid[5]);
     data.WriteByteSeq(whoGuid[6]);
 
-    data << uint8(Index);
+    data << uint8(symbol);
 
     data.WriteByteSeq(whoGuid[4]);
     data.WriteByteSeq(whoGuid[2]);

--- a/src/server/game/Groups/Group.h
+++ b/src/server/game/Groups/Group.h
@@ -348,7 +348,7 @@ class Group
 
         void ChangeMembersGroup(ObjectGuid guid, uint8 group);
         void ChangeMembersGroup(Player* player, uint8 group);
-        void SetTargetIcon(uint8 id, ObjectGuid whoGuid, ObjectGuid targetGuid, uint8 Index);
+        void SetTargetIcon(uint8 symbol, ObjectGuid whoGuid, ObjectGuid targetGuid, uint8 partyIndex);
         void SetGroupMemberFlag(ObjectGuid guid, bool apply, GroupMemberFlags flag);
         void RemoveUniqueGroupMemberFlag(GroupMemberFlags flag);
 

--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -780,8 +780,8 @@ void WorldSession::HandleRaidTargetUpdateOpcode(WorldPacket& recvData)
     if (!group)
         return;
 
-    uint8 Symbol, Index;
-    recvData >> Symbol >> Index;
+    uint8 PartyIndex, Symbol;
+    recvData >> PartyIndex >> Symbol; // PartyIndex always 0 ?
 
     /** error handling **/
     /********************/
@@ -814,7 +814,7 @@ void WorldSession::HandleRaidTargetUpdateOpcode(WorldPacket& recvData)
         recvData.ReadByteSeq(targetGuid[6]);
         recvData.ReadByteSeq(targetGuid[4]);
 
-        group->SetTargetIcon(Symbol, _player->GetGUID(), targetGuid, Index);
+        group->SetTargetIcon(Symbol, _player->GetGUID(), targetGuid, PartyIndex);
     }
 }
 


### PR DESCRIPTION
 - Each index in the `m_targetIcons` array is equal to `iconId`, so `targetGuid` should be saved to its own array index (0-7). At this moment, `targetGuid` is always written to index zero, and the server only stores the last `targetGuid` marked with an icon in its memory, but must store all 8 `targetGuid`s.
 
before fix ( index 0 rewrite ):
![devenv_2024-07-27_20-41-27](https://github.com/user-attachments/assets/a765e46e-d5c6-48c4-a06d-53a1fe5fa735)


after fix ( `m_targetIcons` fully populated ):
![devenv_2024-07-27_22-26-05](https://github.com/user-attachments/assets/bbb6b834-aa47-4893-92c5-3faed9a418f6)
