### PR TITLE
[Core/Chat] addons messages visibility fix

### DIFF
--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -634,7 +634,7 @@ size_t ChatHandler::BuildChatPacket(WorldPacket& data, ChatMsg chatType, Languag
 {
     size_t receiverGUIDPos = 0;
     bool hasAchievementId = (chatType == CHAT_MSG_ACHIEVEMENT || chatType == CHAT_MSG_GUILD_ACHIEVEMENT) && achievementId;
-    bool hasLanguage = (language > Language::LANG_UNIVERSAL);
+    bool hasLanguage = (language > Language::LANG_UNIVERSAL || language == Language::LANG_ADDON);
     bool hasSenderName = false;
     bool hasReceiverName = false;
     bool hasChannelName = false;


### PR DESCRIPTION
- no more spam of addons messages
- addons messages now properly send in LANG_ADDON language and invisible for players

how to test PR:
- install any addon that use addon language to talk with other players addons ( e. g. Details, Carbonite )

before fix:
![Wow-64_Patched_NU_LuaU_2024-07-25_22-31-51](https://github.com/user-attachments/assets/50616d4d-212d-46da-b99b-dc8ff094ac3d)

after fix:
![Wow-64_Patched_NU_LuaU_2024-08-01_02-34-39](https://github.com/user-attachments/assets/bee837e4-8bac-4ab8-a39f-1b88c97e89e0)
