### PR TITLE
Level-up sound on teleport fix

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22085,8 +22085,8 @@ void Player::SendAttackSwingResult(AttackSwingResult result) const
 
 void Player::SendAttackSwingCancelAttack()
 {
-    WorldPacket data(SMSG_CANCEL_COMBAT, 0);
-    GetSession()->SendPacket(&data);
+    //WorldPacket data(SMSG_CANCEL_COMBAT, 0); @TODO : wrong packet opcode
+    //GetSession()->SendPacket(&data);
 }
 
 void Player::SendAutoRepeatCancel(Unit* target)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22085,8 +22085,8 @@ void Player::SendAttackSwingResult(AttackSwingResult result) const
 
 void Player::SendAttackSwingCancelAttack()
 {
-    //WorldPacket data(SMSG_CANCEL_COMBAT, 0); @TODO : wrong packet opcode
-    //GetSession()->SendPacket(&data);
+    WorldPacket data(SMSG_CANCEL_COMBAT, 0);
+    GetSession()->SendPacket(&data);
 }
 
 void Player::SendAutoRepeatCancel(Unit* target)

--- a/src/server/game/Server/Protocol/Opcodes.h
+++ b/src/server/game/Server/Protocol/Opcodes.h
@@ -632,7 +632,7 @@ enum OpcodeServer : uint16
     SMSG_CALENDAR_SEND_EVENT                                     = 0x12AE,
     SMSG_CALENDAR_SEND_NUM_PENDING                               = 0x0A3F,
     SMSG_CANCEL_AUTO_REPEAT                                      = 0x1E0F,
-    SMSG_CANCEL_COMBAT                                           = 0x0534,
+    SMSG_CANCEL_COMBAT                                           = 0x0E8B,
     SMSG_CANCEL_SCENE                                            = 0x120E,
     SMSG_CAST_FAILED                                             = 0x143A,
     SMSG_CHALLENGE_MODE_ALL_MAP_STATS                            = 0x11C2,
@@ -1013,7 +1013,7 @@ enum OpcodeServer : uint16
     SMSG_RANDOM_ROLL                                             = 0x141A,
     SMSG_RANDOMIZE_CHAR_NAME                                     = 0x169F,
     SMSG_READ_ITEM_RESULT_OK                                     = 0x0305,
-    SMSG_READ_ITEM_RESULT_FAILED                                 = 0x0E8B,
+    SMSG_READ_ITEM_RESULT_FAILED                                 = 0x0E8B, // misidentified ?
     SMSG_REALM_SPLIT                                             = 0x1A2E,
     SMSG_RECEIVED_MAIL                                           = 0x182B,
     SMSG_REFER_A_FRIEND_EXPIRED                                  = 0x1143,

--- a/src/server/game/Server/Protocol/Opcodes.h
+++ b/src/server/game/Server/Protocol/Opcodes.h
@@ -1013,7 +1013,7 @@ enum OpcodeServer : uint16
     SMSG_RANDOM_ROLL                                             = 0x141A,
     SMSG_RANDOMIZE_CHAR_NAME                                     = 0x169F,
     SMSG_READ_ITEM_RESULT_OK                                     = 0x0305,
-    SMSG_READ_ITEM_RESULT_FAILED                                 = 0x0E8B, // misidentified ?
+    SMSG_READ_ITEM_RESULT_FAILED                                 = 0x0000, // @TODO
     SMSG_REALM_SPLIT                                             = 0x1A2E,
     SMSG_RECEIVED_MAIL                                           = 0x182B,
     SMSG_REFER_A_FRIEND_EXPIRED                                  = 0x1143,


### PR DESCRIPTION
* no more level-up sound on teleport (x64 client)

* no more "created" message in chat on teleport (x64 client)

* SMSG_READ_ITEM_RESULT_FAILED has wrong opcode

closes https://github.com/Legends-of-Azeroth/Legends-of-Azeroth-Pandaria-5.4.8/issues/280