### PR TITLE
[Core/AuctionHouse] properly display names of auction owners and bidders

### DIFF
--- a/src/server/game/AuctionHouse/AuctionHouseMgr.h
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.h
@@ -80,12 +80,12 @@ struct AuctionEntry
     ObjectGuid::LowType itemGUIDLow;
     uint32 itemEntry;
     uint32 itemCount;
-    ObjectGuid::LowType owner;
+    ObjectGuid owner;
     uint64 startbid;                                        //maybe useless
     uint64 bid;
     uint64 buyout;
     time_t expire_time;
-    ObjectGuid::LowType bidder;
+    ObjectGuid bidder;
     uint64 deposit;                                         //deposit can be calculated only when creating auction
     uint32 etime;
     std::unordered_set<ObjectGuid> bidders;
@@ -100,7 +100,7 @@ struct AuctionEntry
     void SaveToDB(CharacterDatabaseTransaction& trans) const;
     bool LoadFromDB(Field* fields);
     std::string BuildAuctionMailSubject(MailAuctionAnswers response) const;
-    static std::string BuildAuctionMailBody(ObjectGuid::LowType lowGuid, uint64 bid, uint64 buyout, uint64 deposit, uint64 cut);
+    static std::string BuildAuctionMailBody(ObjectGuid guid, uint64 bid, uint64 buyout, uint64 deposit, uint64 cut);
 };
 
 //this class is used as auctionhouse instance

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -74,7 +74,7 @@ bool AuctionBotConfig::Initialize()
                 do
                 {
                     Field* fields = result->Fetch();
-                    _AHBotCharacters.push_back(fields[0].GetUInt32());
+                    _AHBotCharacters.push_back(ObjectGuid::Create<HighGuid::Player>(fields[0].GetUInt32()));
                     ++count;
                 } while (result->NextRow());
             }
@@ -307,35 +307,35 @@ char const* AuctionBotConfig::GetHouseTypeName(AuctionHouseType houseType)
 }
 
 // Picks a random character from the list of AHBot chars
-uint32 AuctionBotConfig::GetRandChar() const
+ObjectGuid AuctionBotConfig::GetRandChar() const
 {
     if (_AHBotCharacters.empty())
-        return 0;
+        return ObjectGuid::Empty;
 
     return Trinity::Containers::SelectRandomContainerElement(_AHBotCharacters);
 }
 
 // Picks a random AHBot character, but excludes a specific one. This is used
 // to have another character than the auction owner place bids
-uint32 AuctionBotConfig::GetRandCharExclude(uint32 exclude) const
+ObjectGuid AuctionBotConfig::GetRandCharExclude(ObjectGuid exclude) const
 {
     if (_AHBotCharacters.empty())
-        return 0;
+        return ObjectGuid::Empty;
 
-    std::vector<uint32> filteredCharacters;
+    std::vector<ObjectGuid> filteredCharacters;
     filteredCharacters.reserve(_AHBotCharacters.size() - 1);
 
-    for (uint32 charId : _AHBotCharacters)
+    for (ObjectGuid charId : _AHBotCharacters)
         if (charId != exclude)
             filteredCharacters.push_back(charId);
 
     if (filteredCharacters.empty())
-        return 0;
+        return ObjectGuid::Empty;
 
     return Trinity::Containers::SelectRandomContainerElement(filteredCharacters);
 }
 
-bool AuctionBotConfig::IsBotChar(uint32 characterID) const
+bool AuctionBotConfig::IsBotChar(ObjectGuid characterID) const
 {
     return !characterID || std::find(_AHBotCharacters.begin(), _AHBotCharacters.end(), characterID) != _AHBotCharacters.end();
 }

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.h
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.h
@@ -231,9 +231,9 @@ public:
 
     uint32 GetItemPerCycleBoost() const { return _itemsPerCycleBoost; }
     uint32 GetItemPerCycleNormal() const { return _itemsPerCycleNormal; }
-    uint32 GetRandChar() const;
-    uint32 GetRandCharExclude(uint32 exclude) const;
-    bool IsBotChar(uint32 characterID) const;
+    ObjectGuid GetRandChar() const;
+    ObjectGuid GetRandCharExclude(ObjectGuid exclude) const;
+    bool IsBotChar(ObjectGuid characterID) const;
     void Reload() { GetConfigFromFile(); }
 
     static char const* GetHouseTypeName(AuctionHouseType houseType);
@@ -241,7 +241,7 @@ public:
 private:
     std::string _AHBotIncludes;
     std::string _AHBotExcludes;
-    std::vector<uint32> _AHBotCharacters;
+    std::vector<ObjectGuid> _AHBotCharacters;
     uint32 _itemsPerCycleBoost;
     uint32 _itemsPerCycleNormal;
 

--- a/src/server/game/AuctionHouseBot/AuctionHouseBotSeller.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBotSeller.cpp
@@ -924,7 +924,7 @@ void AuctionBotSeller::AddNewAuctions(SellerConfiguration& config)
         auctionEntry->startbid = bidPrice;
         auctionEntry->buyout = buyoutPrice;
         auctionEntry->houseId = houseid;
-        auctionEntry->bidder = 0;
+        auctionEntry->bidder = ObjectGuid::Empty;
         auctionEntry->bid = 0;
         auctionEntry->deposit = sAuctionMgr->GetAuctionDeposit(ahEntry, etime, item, stackCount);
         auctionEntry->auctionHouseEntry = ahEntry;

--- a/src/server/game/Handlers/AuctionHouseHandler.cpp
+++ b/src/server/game/Handlers/AuctionHouseHandler.cpp
@@ -457,9 +457,9 @@ void WorldSession::HandleAuctionSellItem(WorldPacket& recvData)
         AH->itemGUIDLow = item->GetGUID().GetCounter();
         AH->itemEntry = item->GetEntry();
         AH->itemCount = item->GetCount();
-        AH->owner = _player->GetGUID().GetCounter();
+        AH->owner = _player->GetGUID();
         AH->startbid = bid;
-        AH->bidder = 0;
+        AH->bidder = ObjectGuid::Empty;
         AH->bid = 0;
         AH->buyout = buyout;
         AH->expire_time = GameTime::GetGameTime() + auctionTime;
@@ -514,9 +514,9 @@ void WorldSession::HandleAuctionSellItem(WorldPacket& recvData)
         AH->itemGUIDLow = newItem->GetGUID().GetCounter();
         AH->itemEntry = newItem->GetEntry();
         AH->itemCount = newItem->GetCount();
-        AH->owner = _player->GetGUID().GetCounter();
+        AH->owner = _player->GetGUID();
         AH->startbid = bid;
-        AH->bidder = 0;
+        AH->bidder = ObjectGuid::Empty;
         AH->bid = 0;
         AH->buyout = buyout;
         AH->expire_time = GameTime::GetGameTime() + auctionTime;
@@ -625,7 +625,7 @@ void WorldSession::HandleAuctionPlaceBid(WorldPacket& recvData)
     AuctionEntry* auction = auctionHouse->GetAuction(auctionId);
     Player* player = GetPlayer();
 
-    if (!auction || auction->owner == player->GetGUID().GetCounter())
+    if (!auction || auction->owner == player->GetGUID())
     {
         //you cannot bid your own auction:
         SendAuctionCommandResult(NULL, AUCTION_PLACE_BID, ERR_AUCTION_BID_OWN);
@@ -679,7 +679,7 @@ void WorldSession::HandleAuctionPlaceBid(WorldPacket& recvData)
         else
             player->ModifyMoney(-int64(price));
 
-        auction->bidder = player->GetGUID().GetCounter();
+        auction->bidder = player->GetGUID();
         auction->bid = price;
         GetPlayer()->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_AUCTION_BID, price);
 
@@ -712,7 +712,7 @@ void WorldSession::HandleAuctionPlaceBid(WorldPacket& recvData)
             if (auction->bidder)                          //buyout for bidded auction ..
                 sAuctionMgr->SendAuctionOutbiddedMail(auction, auction->buyout, GetPlayer(), trans);
         }
-        auction->bidder = player->GetGUID().GetCounter();
+        auction->bidder = player->GetGUID();
         auction->bid = auction->buyout;
         GetPlayer()->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HIGHEST_AUCTION_BID, auction->buyout);
 
@@ -777,7 +777,7 @@ void WorldSession::HandleAuctionRemoveItem(WorldPacket& recvData)
     Player* player = GetPlayer();
 
     CharacterDatabaseTransaction trans = CharacterDatabase.BeginTransaction();
-    if (auction && auction->owner == player->GetGUID().GetCounter())
+    if (auction && auction->owner == player->GetGUID())
     {
         Item* pItem = sAuctionMgr->GetAItem(auction->itemGUIDLow);
         if (pItem)
@@ -792,7 +792,7 @@ void WorldSession::HandleAuctionRemoveItem(WorldPacket& recvData)
             }
 
             // item will deleted or added to received mail list
-            MailDraft(auction->BuildAuctionMailSubject(AUCTION_CANCELED), AuctionEntry::BuildAuctionMailBody(0, 0, auction->buyout, auction->deposit, 0))
+            MailDraft(auction->BuildAuctionMailSubject(AUCTION_CANCELED), AuctionEntry::BuildAuctionMailBody(ObjectGuid::Empty, 0, auction->buyout, auction->deposit, 0))
                 .AddItem(pItem)
                 .SendMailTo(trans, player, auction, MAIL_CHECK_MASK_COPIED);
         }


### PR DESCRIPTION
Use full `ObjectGuid` instead of `ObjectGuid::LowType` for owner and bidders in AH manager, AH bot and auction info in packets.