### PR TITLE
[Core/Packet] SMSG_RAID_TARGET_UPDATE_ALL proper implementation

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -18,6 +18,7 @@
 #include "Common.h"
 #include "Opcodes.h"
 #include "WorldPacket.h"
+#include "PartyPackets.h"
 #include "WorldSession.h"
 #include "Player.h"
 #include "World.h"
@@ -1878,100 +1879,18 @@ void Group::SetTargetIcon(uint8 symbol, ObjectGuid whoGuid, ObjectGuid targetGui
     BroadcastPacket(&data, true);
 }
 
-void Group::SendTargetIconList(WorldSession* session)
+void Group::SendTargetIconList(WorldSession* session, int8 partyIndex)
 {
     if (!session)
         return;
 
-    /*uint8 Index = 0;
-    WorldPacket data(SMSG_RAID_TARGET_UPDATE_ALL, (1 + TARGETICONCOUNT * 9));
-    data.WriteBits(0, 25);
+    WorldPackets::Party::SendRaidTargetUpdateAll updateAll;
+    updateAll.PartyIndex = partyIndex;
+    for (uint8 i = 0; i < TARGETICONCOUNT; i++)
+        if (m_targetIcons[i] != ObjectGuid::Empty)
+            updateAll.TargetIcons.insert(std::pair<uint8, ObjectGuid>(i, m_targetIcons[i]));
 
-    for (uint8 i = 0; i < TARGETICONCOUNT; ++i)
-    {
-        if (m_targetIcons[i] == 0)
-            continue;
-
-        ObjectGuid guid = m_targetIcons[i];
-
-        data.WriteBit(guid[2]);
-        data.WriteBit(guid[1]);
-        data.WriteBit(guid[3]);
-        data.WriteBit(guid[7]);
-        data.WriteBit(guid[6]);
-        data.WriteBit(guid[4]);
-        data.WriteBit(guid[0]);
-        data.WriteBit(guid[5]);
-
-        data.WriteByteSeq(guid[4]);
-        data.WriteByteSeq(guid[7]);
-        data.WriteByteSeq(guid[1]);
-        data.WriteByteSeq(guid[0]);
-        data.WriteByteSeq(guid[6]);
-        data.WriteByteSeq(guid[5]);
-        data.WriteByteSeq(guid[3]);
-        data << uint8(i);
-        data.WriteByteSeq(guid[2]);
-    }
-
-    data << uint8(Index);
-
-    session->SendPacket(&data);*/
-
-    //-- SMSG_RAID_TARGET_UPDATE_ALL : packed wrong so we use workaround
-    ObjectGuid whoGuid = GetLeaderGUID();
-
-    for (uint8 i = 0; i < TARGETICONCOUNT; ++i)
-    {
-        if (m_targetIcons[i] == 0)
-            continue;
-
-        ObjectGuid targetGuid = m_targetIcons[i];
-
-        WorldPacket data(SMSG_RAID_TARGET_UPDATE_SINGLE, 8 + 1 + 8 + 1);
-
-        data.WriteBit(whoGuid[6]);
-        data.WriteBit(targetGuid[4]);
-        data.WriteBit(whoGuid[0]);
-        data.WriteBit(whoGuid[7]);
-        data.WriteBit(targetGuid[6]);
-        data.WriteBit(whoGuid[5]);
-        data.WriteBit(whoGuid[3]);
-        data.WriteBit(whoGuid[4]);
-        data.WriteBit(targetGuid[7]);
-        data.WriteBit(targetGuid[2]);
-        data.WriteBit(targetGuid[5]);
-        data.WriteBit(targetGuid[1]);
-        data.WriteBit(whoGuid[2]);
-        data.WriteBit(whoGuid[1]);
-        data.WriteBit(targetGuid[0]);
-        data.WriteBit(targetGuid[3]);
-
-        data.WriteByteSeq(targetGuid[1]);
-
-        data << uint8(0);
-
-        data.WriteByteSeq(whoGuid[0]);
-        data.WriteByteSeq(whoGuid[5]);
-        data.WriteByteSeq(whoGuid[3]);
-        data.WriteByteSeq(targetGuid[7]);
-        data.WriteByteSeq(targetGuid[6]);
-        data.WriteByteSeq(whoGuid[1]);
-        data.WriteByteSeq(targetGuid[2]);
-        data.WriteByteSeq(targetGuid[4]);
-        data.WriteByteSeq(targetGuid[0]);
-        data.WriteByteSeq(targetGuid[3]);
-        data.WriteByteSeq(targetGuid[5]);
-        data.WriteByteSeq(whoGuid[6]);
-
-        data << uint8(i);
-
-        data.WriteByteSeq(whoGuid[4]);
-        data.WriteByteSeq(whoGuid[2]);
-        data.WriteByteSeq(whoGuid[7]);
-
-        BroadcastPacket(&data, true);
-    }
+    session->SendPacket(updateAll.Write());
 }
 
 void Group::SendUpdate()

--- a/src/server/game/Groups/Group.h
+++ b/src/server/game/Groups/Group.h
@@ -370,7 +370,7 @@ class Group
 
         // -no description-
         //void SendInit(WorldSession* session);
-        void SendTargetIconList(WorldSession* session);
+        void SendTargetIconList(WorldSession* session, int8 partyIndex = 0);
         void SendUpdate();
         void SendUpdateToPlayer(ObjectGuid playerGUID);
         void SendGroupRemoved(ObjectGuid playerGUID);

--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -781,7 +781,7 @@ void WorldSession::HandleRaidTargetUpdateOpcode(WorldPacket& recvData)
         return;
 
     uint8 PartyIndex, Symbol;
-    recvData >> PartyIndex >> Symbol; // PartyIndex always 0 ?
+    recvData >> PartyIndex >> Symbol;
 
     /** error handling **/
     /********************/
@@ -1626,15 +1626,15 @@ void WorldSession::HandleGroupRequestJoinUpdates(WorldPacket& recvData)
 {
     TC_LOG_DEBUG("network", "WORLD: Received CMSG_GROUP_REQUEST_JOIN_UPDATES");
 
-    uint8 unk;
-    recvData >> unk; // PartyIndex
+    uint8 PartyIndex;
+    recvData >> PartyIndex;
 
     Group* group = GetPlayer()->GetGroup();
     if (!group)
         return;
 
     group->SendUpdate();
-    group->SendTargetIconList(this);
+    group->SendTargetIconList(this, PartyIndex);
 }
 
 void WorldSession::HandleClearRaidMarkerOpcode(WorldPacket& recvData)

--- a/src/server/game/Server/Packets/PartyPackets.cpp
+++ b/src/server/game/Server/Packets/PartyPackets.cpp
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the Legends of Azeroth Pandaria Project. See THANKS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PartyPackets.h"
+
+WorldPacket const* WorldPackets::Party::SendRaidTargetUpdateAll::Write()
+{
+    _worldPacket.WriteBits(TargetIcons.size(), 23);
+
+    ByteBuffer dataBuffer;
+
+    for (auto itr = TargetIcons.begin(); itr != TargetIcons.end(); ++itr)
+    {
+        ObjectGuid guid = itr->second;
+
+        _worldPacket.WriteBit(guid[2]);
+        _worldPacket.WriteBit(guid[1]);
+        _worldPacket.WriteBit(guid[3]);
+        _worldPacket.WriteBit(guid[7]);
+        _worldPacket.WriteBit(guid[6]);
+        _worldPacket.WriteBit(guid[4]);
+        _worldPacket.WriteBit(guid[0]);
+        _worldPacket.WriteBit(guid[5]);
+
+        dataBuffer.WriteByteSeq(guid[4]);
+        dataBuffer.WriteByteSeq(guid[7]);
+        dataBuffer.WriteByteSeq(guid[1]);
+        dataBuffer.WriteByteSeq(guid[0]);
+        dataBuffer.WriteByteSeq(guid[6]);
+        dataBuffer.WriteByteSeq(guid[5]);
+        dataBuffer.WriteByteSeq(guid[3]);
+        dataBuffer << (uint8)itr->first;
+        dataBuffer.WriteByteSeq(guid[2]);
+    }
+
+    _worldPacket.append(dataBuffer);
+    _worldPacket << (uint8)PartyIndex; // 0 = home(local) group, 1 = away(LFG etc.) group
+
+    return &_worldPacket;
+}

--- a/src/server/game/Server/Packets/PartyPackets.h
+++ b/src/server/game/Server/Packets/PartyPackets.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the Legends of Azeroth Pandaria Project. See THANKS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PartyPackets_h__
+#define PartyPackets_h__
+
+#include "Packet.h"
+#include "ObjectGuid.h"
+#include "Group.h"
+
+namespace WorldPackets
+{
+    namespace Party
+    {
+        class SendRaidTargetUpdateAll final : public ServerPacket
+        {
+        public:
+            SendRaidTargetUpdateAll() : ServerPacket(SMSG_RAID_TARGET_UPDATE_ALL, 1 + TARGETICONCOUNT * 9) { }
+
+            WorldPacket const* Write() override;
+
+            int8 PartyIndex = 0;
+            std::map<uint8, ObjectGuid> TargetIcons;
+        };
+    }
+}
+
+#endif // PartyPackets_h__


### PR DESCRIPTION
* `TargetIcon`s are now properly sent to the client in one batch.
* `TargetIcon`s are now correctly updated for new members or on relog, in both home(local) groups and away(LFG, etc.) groups.

to test PR:
* create party/raid ( 2 players minimum )
* mark targets with `TargetIcon`s
* invite 3rd player to party/raid
* this player will receive `TargetIcon`s

https://youtu.be/_3orpm96yH4