### PR TITLE
[Core/Map] Lower some mmap logs from ERROR to WARN/DEBUG

### DIFF
--- a/src/common/Collision/Management/MMapManager.cpp
+++ b/src/common/Collision/Management/MMapManager.cpp
@@ -133,7 +133,7 @@ namespace MMAP
         FILE* file = fopen(fileName.c_str(), "rb");
         if (!file)
         {
-            TC_LOG_ERROR("maps", "MMAP:loadMap: Could not open mmtile file '%s'", fileName.c_str());
+            TC_LOG_DEBUG("maps", "MMAP:loadMap: Could not open mmtile file '%s'", fileName.c_str());
             return false;
         }
 

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -151,7 +151,7 @@ void Map::LoadMMap(int gx, int gy)
     if (mmapLoadResult)
         TC_LOG_DEBUG("maps", "MMAP loaded name:%s, id:%d, x:%d, y:%d (mmap rep.: x:%d, y:%d)", GetMapName(), GetId(), gx, gy, gx, gy);
     else 
-        TC_LOG_ERROR("maps", "Could not load MMAP name:%s, id:%d, x:%d, y:%d (mmap rep.: x:%d, y:%d)", GetMapName(), GetId(), gx, gy, gx, gy);
+        TC_LOG_WARN("maps", "Could not load MMAP name:%s, id:%d, x:%d, y:%d (mmap rep.: x:%d, y:%d)", GetMapName(), GetId(), gx, gy, gx, gy);
 }
 
 void Map::LoadVMap(int gx, int gy)


### PR DESCRIPTION
Updated to match TC log levels; see https://github.com/TrinityCore/TrinityCore/commit/42ab6010f862e530517e2acd347ef6230bcf1c3b

> Move "Could not load MMAP" log from ERROR to WARN as 99% of times is a false positive

This resolves https://github.com/Legends-of-Azeroth/Legends-of-Azeroth-Pandaria-5.4.8/issues/222