### PR TITLE
Core/GameObject: fix acherus soul prison interaction

### DIFF
--- a/src/server/game/AI/CoreAI/GameObjectAI.h
+++ b/src/server/game/AI/CoreAI/GameObjectAI.h
@@ -46,7 +46,7 @@ class TC_GAME_API GameObjectAI
 
         static int Permissible(GameObject const* go);
 
-        virtual bool OnGossipHello(Player* /*player*/) { return false; }
+        virtual bool OnGossipHello(Player* /*player*/, bool /*isUse*/) { return false; }
         virtual bool OnReportUse(Player* /*player*/) { return false; }
         virtual bool OnGossipSelect(Player* /*player*/, uint32 /*sender*/, uint32 /*action*/) { return false; }
         virtual bool OnGossipSelectCode(Player* /*player*/, uint32 /*sender*/, uint32 /*action*/, char const* /*code*/) { return false; }

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -1002,7 +1002,7 @@ void SmartGameObjectAI::Reset()
 }
 
 // Called when a player opens a gossip dialog with the gameobject.
-bool SmartGameObjectAI::OnGossipHello(Player* player)
+bool SmartGameObjectAI::OnGossipHello(Player* player, bool /*isUse*/)
 {
     _gossipReturn = false;
     GetScript()->ProcessEventsFor(SMART_EVENT_GOSSIP_HELLO, player, 0, 0, false, nullptr, me);

--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -276,7 +276,7 @@ class TC_GAME_API SmartGameObjectAI : public GameObjectAI
         SmartScript* GetScript() { return &mScript; }
         static int Permissible(const GameObject* g);
 
-        bool OnGossipHello(Player* player) override;
+        bool OnGossipHello(Player* player, bool isUse) override;
         bool OnReportUse(Player* player) override;
         bool OnGossipSelect(Player* player, uint32 sender, uint32 action) override;
         bool OnGossipSelectCode(Player* /*player*/, uint32 /*sender*/, uint32 /*action*/, const char* /*code*/) override;

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -54,6 +54,7 @@ GameObject::GameObject() : WorldObject(false), MapObject(),
     m_usetimes = 0;
     m_spellId = 0;
     m_cooldownTime = 0;
+    m_prevGoState = GO_STATE_ACTIVE;
     m_goInfo = NULL;
     m_ritualOwner = NULL;
     m_goData = NULL;
@@ -276,6 +277,7 @@ bool GameObject::Create(ObjectGuid::LowType guidlow, uint32 name_id, Map* map, u
     CreateModel();
     // GAMEOBJECT_FIELD_STATE_SPELL_VISUAL_ID, index at 0, 1, 2 and 3
     SetGoType(GameobjectTypes(goinfo->type));
+    m_prevGoState = go_state;
     SetGoState(go_state);
     SetGoArtKit(artKit);
 
@@ -1213,7 +1215,9 @@ void GameObject::ResetDoorOrButton()
     if (m_lootState == GO_READY || m_lootState == GO_JUST_DEACTIVATED)
         return;
 
-    SwitchDoorOrButton(false);
+    RemoveFlag(GAMEOBJECT_FIELD_FLAGS, GO_FLAG_IN_USE);
+    SetGoState(m_prevGoState);
+
     SetLootState(GO_JUST_DEACTIVATED);
     m_cooldownTime = 0;
 }
@@ -1289,7 +1293,7 @@ void GameObject::Use(Unit* user)
         if (sScriptMgr->OnGossipHello(playerUser, this))
             return;
 
-        if (AI()->OnGossipHello(playerUser))
+        if (AI()->OnGossipHello(playerUser, true))
             return;
     }
 

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -372,6 +372,8 @@ class TC_GAME_API GameObject : public WorldObject, public GridObject<GameObject>
         time_t      m_cooldownTime;                         // used as internal reaction delay time store (not state change reaction).
         uint32      m_trapCooldownTime = 0;                 // higher resolution timer than time_t, used only for traps
 
+        GOState     m_prevGoState;                          // What state to set whenever resetting
+
         std::list<uint32> m_SkillupList;
 
         Player* m_ritualOwner;                              // used for GAMEOBJECT_TYPE_SUMMONING_RITUAL where GO is not summoned (no owner)

--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -666,7 +666,7 @@ void WorldSession::HandleGameobjectReportUse(WorldPacket& recvPacket)
         return;
 
     // only for backward compatibility
-    if (go->AI()->OnGossipHello(_player))
+    if (go->AI()->OnGossipHello(_player, false))
         return;
 
     if (go->AI()->OnReportUse(_player))

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2197,7 +2197,7 @@ void Spell::SendLoot(ObjectGuid guid, LootType loottype)
         if (sScriptMgr->OnGossipHello(player, gameObjTarget))
             return;
 
-        if (gameObjTarget->AI()->OnGossipHello(player))
+        if (gameObjTarget->AI()->OnGossipHello(player, true))
             return;
 
         switch (gameObjTarget->GetGoType())

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -22,6 +22,7 @@
 #include "ObjectMgr.h"
 #include "ScriptedEscortAI.h"
 #include "CombatAI.h"
+#include "GameObjectAI.h"
 #include "PassiveAI.h"
 #include "Player.h"
 #include "SpellInfo.h"
@@ -310,19 +311,33 @@ public:
 
 class go_acherus_soul_prison : public GameObjectScript
 {
-public:
-    go_acherus_soul_prison() : GameObjectScript("go_acherus_soul_prison") { }
+    public:
+        go_acherus_soul_prison() : GameObjectScript("go_acherus_soul_prison") { }
 
-    bool OnGossipHello(Player* player, GameObject* go) override
-    {
-        if (Creature* anchor = go->FindNearestCreature(29521, 15))
-            if (ObjectGuid prisonerGUID = anchor->AI()->GetGUID())
-                if (Creature* prisoner = Creature::GetCreature(*player, prisonerGUID))
-                    CAST_AI(npc_unworthy_initiate::npc_unworthy_initiateAI, prisoner->AI())->EventStart(anchor, player);
+        struct go_acherus_soul_prisonAI : public GameObjectAI
+        {
+            go_acherus_soul_prisonAI(GameObject* go) : GameObjectAI(go)
+            {
+            }
 
-        return false;
-    }
+            bool OnGossipHello(Player* player, bool isUse) override
+            {
+                if (!isUse)
+                    return true;
 
+                if (Creature* anchor = me->FindNearestCreature(29521, 15))
+                    if (ObjectGuid prisonerGUID = anchor->AI()->GetGUID())
+                        if (Creature* prisoner = Creature::GetCreature(*player, prisonerGUID))
+                            CAST_AI(npc_unworthy_initiate::npc_unworthy_initiateAI, prisoner->AI())->EventStart(anchor, player);
+
+                return false;
+            }
+        };
+
+        GameObjectAI* GetAI(GameObject* go) const override
+        {
+            return new go_acherus_soul_prisonAI(go);
+        }
 };
 
 enum EyeOfAcherusMisc

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
@@ -1297,8 +1297,11 @@ class go_twilight_portal : public GameObjectScript
                 }
             }
 
-            bool OnGossipHello(Player* player) override
+            bool OnGossipHello(Player* player, bool isUse) override
             {
+                if (!isUse)
+                    return true;
+
                 if (_spellId != 0)
                     player->CastSpell(player, _spellId, true);
                 return true;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -1170,8 +1170,11 @@ class go_celestial_planetarium_access : public GameObjectScript
         {
             go_celestial_planetarium_accessAI(GameObject* go) : GameObjectAI(go) { }
 
-            bool OnGossipHello(Player* player) override
+            bool OnGossipHello(Player* player, bool isUse) override
             {
+                if (!isUse)
+                    return true;
+
                 if (me->HasFlag(GAMEOBJECT_FIELD_FLAGS, GO_FLAG_IN_USE))
                     return false;
                 if (me->FindNearestCreature(NPC_BRANN_BRONZBEARD_ALG, 50.0f))

--- a/src/server/scripts/Pandaria/MogushanVault/boss_feng.cpp
+++ b/src/server/scripts/Pandaria/MogushanVault/boss_feng.cpp
@@ -1448,8 +1448,11 @@ class go_inversion : public GameObjectScript
         {
             go_inversionAI(GameObject* go) : GameObjectAI(go) { }
 
-            bool OnGossipHello(Player* player) override
+            bool OnGossipHello(Player* player, bool isUse) override
             {
+                if (!isUse)
+                    return true;
+
                 if (!player->IsInCombat())
                     return true;
 
@@ -1483,8 +1486,11 @@ class go_cancel : public GameObjectScript
         {
             go_cancelAI(GameObject* go) : GameObjectAI(go) { }
 
-            bool OnGossipHello(Player* player) override
+            bool OnGossipHello(Player* player, bool isUse) override
             {
+                if (!isUse)
+                    return true;
+
                 if (!player->IsInCombat())
                     return true;
 

--- a/src/server/scripts/Pandaria/ThroneOfThunder/boss_horridon.cpp
+++ b/src/server/scripts/Pandaria/ThroneOfThunder/boss_horridon.cpp
@@ -2000,8 +2000,11 @@ class go_horridon_orb_of_control : public GameObjectScript
         {
             go_horridon_orb_of_control_AI(GameObject *go) : GameObjectAI(go) { }
 
-            bool OnGossipHello(Player* player) override
+            bool OnGossipHello(Player* player, bool isUse) override
             {
+                if (!isUse)
+                    return true;
+
                 if (uint32 spellId = GetControlSpellByOrb(me->GetEntry()))
                 {
                     player->CastSpell(player, spellId, true);

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -879,12 +879,11 @@ class go_soulwell : public GameObjectScript
             {
             }
 
-            /// Due to the fact that this GameObject triggers CMSG_GAMEOBJECT_USE
-            /// _and_ CMSG_GAMEOBJECT_REPORT_USE, this GossipHello hook is called
-            /// twice. The script's handling is fine as it won't remove two charges
-            /// on the well. We have to find how to segregate REPORT_USE and USE.
-            bool OnGossipHello(Player* player) override
+            bool OnGossipHello(Player* player, bool isUse) override
             {
+                if (!isUse)
+                    return true;
+
                 Unit* owner = me->GetOwner();
                 if (!owner || owner->GetTypeId() != TYPEID_PLAYER || !player->IsInSameRaidWith(owner->ToPlayer()))
                     return true;


### PR DESCRIPTION
This fixes tooltips and interaction with the Acherus Soul Prison game objects used in the quest https://www.wowhead.com/quest=12848/the-endless-hunger.

First, the `npc_unworthy_initiate` script called `prison->ResetDoorOrButton()` which left the game objects in a bad state (`GO_STATE_ACTIVE` instead of `GO_STATE_READY`). Now, `ResetDoorOrButton` will restore game object state from database. Fix is from https://github.com/TrinityCore/TrinityCore/commit/8a3f053a2f82460cf5d856404f6fcaf4b7eb44aa.

Second, `CMSG_GAMEOBJ_REPORT_USE` (attempting to use a locked game object) calls `OnGossipHello` "for backward compatibility" with nothing to disambiguate from `CMSG_GAMEOBJ_USE` (using a game object after successfully unlocking it). Now, an additional `isUse` parameter is passed. Fix is from https://github.com/TrinityCore/TrinityCore/commit/b539ac6afafbddcb75855511d66d97bbc2e95c30.

`go_acherus_soul_prison` script has also been updated to use `GameObjectAI` which has `OnGossipHello` that takes `inUse` parameter.