### PR TITLE
Core/Pools: fix spawning pooled creatures and gameobjects

### DIFF
--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -17,6 +17,7 @@
 
 #include "PoolMgr.h"
 #include "Containers.h"
+#include "GameEventMgr.h"
 #include "ObjectMgr.h"
 #include "Log.h"
 #include "MapManager.h"
@@ -350,6 +351,11 @@ void PoolGroup<Creature>::Spawn1Object(ActivePoolData& spawns, PoolObject* obj)
 {
     if (CreatureData const* data = sObjectMgr->GetCreatureData(obj->guid))
     {
+        if (data->gameEventId && !sGameEventMgr->IsActiveEvent(data->gameEventId))
+            return;
+
+        sObjectMgr->AddCreatureToGrid(obj->guid, data);
+
         // Spawn if necessary (loaded grids only)
         // We use spawn coords to spawn
         if (spawns.GetMap()->IsGridLoaded(data->posX, data->posY))
@@ -371,6 +377,11 @@ void PoolGroup<GameObject>::Spawn1Object(ActivePoolData& spawns, PoolObject* obj
 {
     if (GameObjectData const* data = sObjectMgr->GetGOData(obj->guid))
     {
+        if (data->gameEventId && !sGameEventMgr->IsActiveEvent(data->gameEventId))
+            return;
+
+        sObjectMgr->AddGameobjectToGrid(obj->guid, data);
+
         // Spawn if necessary (loaded grids only)
         // We use current coords to unspawn, not spawn coords since creature can have changed grid
         if (spawns.GetMap()->IsGridLoaded(data->posX, data->posY))


### PR DESCRIPTION
With this fix, pooled creatures and gameobjects are properly added to the map.

I tested with cobalt https://www.wowhead.com/object=189978/cobalt-deposit - you can log guids in `PoolGroup<GameObject>::Spawn1Object(ActivePoolData& spawns, PoolObject* obj)` when `data->id == 189978` or something similar, then use `.go obj [guid]` to teleport directly to the cobalt node and verify that it's actually in the map.