### PR TITLE
Fix wrong path for openssl build workflow

### DIFF
--- a/.github/workflows/windows-build-release.yml
+++ b/.github/workflows/windows-build-release.yml
@@ -77,8 +77,8 @@ jobs:
         
         dir
           copy "C:/Program Files/MySQL/MySQL Server 8.0/lib/libmysql.dll" ${{github.workspace}}/build/bin/RelWithDebInfo/libmysql.dll
-          copy "C:/Program Files/OpenSSL-Win64/bin/libcrypto-3-x64.dll" ${{github.workspace}}/build/bin/RelWithDebInfo/libcrypto-3-x64.dll
-          copy "C:/Program Files/OpenSSL-Win64/bin/libssl-3-x64.dll" ${{github.workspace}}/build/bin/RelWithDebInfo/libssl-3-x64.dll
+          copy "C:/Program Files/OpenSSL/bin/libcrypto-3-x64.dll" ${{github.workspace}}/build/bin/RelWithDebInfo/libcrypto-3-x64.dll
+          copy "C:/Program Files/OpenSSL/bin/libssl-3-x64.dll" ${{github.workspace}}/build/bin/RelWithDebInfo/libssl-3-x64.dll
           move ${{github.workspace}}/contrib/lua_scripts ${{github.workspace}}/build/bin/RelWithDebInfo/lua_scripts
         
         ./authserver --version


### PR DESCRIPTION
From the last build workflow openssl has return this folder location:

-- Found OpenSSL: optimized;C:/Program Files/OpenSSL/lib/VC/libcrypto64MD.lib;debug;C:/Program Files/OpenSSL/lib/VC/libcrypto64MDd.lib (found suitable version "3.1.1", minimum required is "1.1") found components: Crypto SSL
-- Found OpenSSL library: optimized;C:/Program Files/OpenSSL/lib/VC/libssl64MD.lib;debug;C:/Program Files/OpenSSL/lib/VC/libssl64MDd.lib;optimized;C:/Program Files/OpenSSL/lib/VC/libcrypto64MD.lib;debug;C:/Program Files/OpenSSL/lib/VC/libcrypto64MDd.lib
-- Found OpenSSL headers: C:/Program Files/OpenSSL/include

I was specifing OpensSSL-Win64/ instead of OpenSsl/