### PR TITLE
Update AES and ARC4 crypto classes for OpenSSL 1.1+ compatibility

### DIFF
--- a/src/common/Cryptography/AES.cpp
+++ b/src/common/Cryptography/AES.cpp
@@ -21,7 +21,6 @@
 
 Trinity::Crypto::AES::AES(bool encrypting) : _ctx(EVP_CIPHER_CTX_new()), _encrypting(encrypting)
 {
-    EVP_CIPHER_CTX_init(_ctx);
     int status = EVP_CipherInit_ex(_ctx, EVP_aes_128_gcm(), nullptr, nullptr, nullptr, _encrypting ? 1 : 0);
     ASSERT(status);
 }

--- a/src/common/Cryptography/ARC4.cpp
+++ b/src/common/Cryptography/ARC4.cpp
@@ -26,7 +26,6 @@ Trinity::Crypto::ARC4::ARC4() : _ctx(EVP_CIPHER_CTX_new())
     EVP_CIPHER const* _cipher = EVP_rc4();
 #endif
 
-    EVP_CIPHER_CTX_init(_ctx);
     int result = EVP_EncryptInit_ex(_ctx, _cipher, nullptr, nullptr, nullptr);
     ASSERT(result == 1);
 }


### PR DESCRIPTION
### Motivation
OpenSSL 1.1+ removed `EVP_CIPHER_CTX_init()` and other legacy functions. Without these changes, the code fails to compile with modern OpenSSL versions (tested with 1.1.1.23).