### PR TITLE
fix: connection patcher reconnect crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build/
 .idea/
 /bin-clang
 /bin
+bin/
+obj/

--- a/contrib/SkyFire Patcher/548/Source/Client Patcher/Patches/Windows.cs
+++ b/contrib/SkyFire Patcher/548/Source/Client Patcher/Patches/Windows.cs
@@ -24,7 +24,7 @@ namespace Connection_Patcher.Patches
             public static byte[] Send  = { 0x33, 0xC0, 0x90 };
             public static byte[] Email = { 0x90, 0x90, 0xEB };
             public static byte[] User  = { 0x00 };
-            public static byte[] RaF   = { 0x90, 0x90, 0x90, 0x90, 0x90 };
+            public static byte[] RaF   = { 0x33, 0xC0, 0x90, 0x90, 0x90 };
             public static byte[] Rcv   = { 0xFF, 0x0F, 0x084 };
         }
 
@@ -33,7 +33,7 @@ namespace Connection_Patcher.Patches
             public static byte[] Send  = { 0x45, 0x31, 0xC0, 0x90, 0x90 };
             public static byte[] Email = { 0xEB };
             public static byte[] User  = { 0x00 };
-            public static byte[] RaF   = { 0x90, 0x90, 0x90, 0x90, 0x90 };
+            public static byte[] RaF   = { 0x33, 0xC0, 0x90, 0x90, 0x90 };
             public static byte[] Rcv   = { 0xFF, 0x0F, 0x84 };
         }
     }


### PR DESCRIPTION
Switching accounts often causes the (Windows) client to crash; this fixes.